### PR TITLE
Fix early wrapping in flow layout with padding

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/pane/FlowPane.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/pane/FlowPane.java
@@ -199,7 +199,7 @@ public class FlowPane extends Pane {
 		for (Node child : getChildren()) {
 			final int childLength = orientation == Orientation.HORIZONTAL ? child.getWidth() : child.getHeight();
 			final int childWidth = orientation == Orientation.HORIZONTAL ? child.getHeight() : child.getWidth();
-			if ((orientation == Orientation.HORIZONTAL ? x : y) + childLength > maxLength && length > 0) {
+			if (length + childLength > maxLength && length > 0) {
 				if (orientation == Orientation.HORIZONTAL) {
 					x = leftPadding;
 					y += width + vGap;


### PR DESCRIPTION
Fix `FlowPane` wrapping its content too early as stated in #1.