### PR TITLE
Fix not rendered background with empty children

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
@@ -172,7 +172,7 @@ public abstract class Parent extends Node {
 		final boolean isInBounds = x >= 0 && y >= 0 && x < getWidth() && y < getHeight();
 
 		if (children.isEmpty()) {
-			return null;
+			return background != null && isInBounds ? background.backgroundAt(x, y) : null;
 		}
 
 		if (!isInBounds && isClipping()) {


### PR DESCRIPTION
Fixes the background of a `Parent` not being rendered when its children list is empty as stated in #9.