### PR TITLE
Hide internal API

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -61,6 +61,20 @@ import java.util.function.Consumer;
  */
 public abstract class Node {
 
+	static {
+		NodeHelper.setNodeAccessor(new NodeHelper.NodeAccessor() {
+			@Override
+			public void setScene(Node node, Scene scene) {
+				node.setScene(scene);
+			}
+
+			@Override
+			public void setParent(Node node, Parent parent) {
+				node.setParent(parent);
+			}
+		});
+	}
+
 	private Scene scene;
 	private Parent parent;
 
@@ -92,13 +106,11 @@ public abstract class Node {
 
 	/**
 	 * Sets the scene that this node is in.
-	 * <b>This method is part of the internal API and should not be called by users.</b>
-	 * If you want to set the scene of a node, use {@link Scene#setRoot(Parent)}.
 	 *
 	 * @param scene the scene that this node is in
 	 * @since 2.0.0
 	 */
-	public final void setScene(Scene scene) {
+	private void setScene(Scene scene) {
 		this.scene = scene;
 		if (this instanceof Parent asParent) {
 			for (Node child : asParent.getChildren()) {
@@ -118,7 +130,13 @@ public abstract class Node {
 		return parent;
 	}
 
-	protected final void setParent(Parent parent) {
+	/**
+	 * Sets the parent of this node.
+	 *
+	 * @param parent the parent of this node
+	 * @since 1.0.0
+	 */
+	private void setParent(Parent parent) {
 		this.parent = parent;
 	}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/NodeHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/NodeHelper.java
@@ -1,0 +1,46 @@
+package io.github.somesourcecode.someguiapi.scene;
+
+/**
+ * A helper class for nodes to access internal methods.
+ *
+ * @since 2.0.0
+ */
+public class NodeHelper {
+
+	private static NodeAccessor nodeAccessor;
+
+	private NodeHelper() {
+
+	}
+
+	public static void setScene(Node node, Scene scene) {
+		nodeAccessor.setScene(node, scene);
+	}
+
+	public static void setParent(Node node, Parent parent) {
+		nodeAccessor.setParent(node, parent);
+	}
+
+	public static void setNodeAccessor(final NodeAccessor newAccessor) {
+		if (nodeAccessor != null) {
+			throw new IllegalStateException();
+		}
+		nodeAccessor = newAccessor;
+	}
+
+	public static NodeAccessor getNodeAccessor() {
+		if (nodeAccessor == null) {
+			throw new IllegalStateException();
+		}
+		return nodeAccessor;
+	}
+
+	public interface NodeAccessor {
+
+		void setScene(Node node, Scene scene);
+
+		void setParent(Node node, Parent parent);
+
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/NodeHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/NodeHelper.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
@@ -25,6 +25,7 @@ package io.github.somesourcecode.someguiapi.scene;
 
 import io.github.somesourcecode.someguiapi.collections.ObservableList;
 import io.github.somesourcecode.someguiapi.collections.ObservableListBase;
+import io.github.somesourcecode.someguiapi.scene.gui.GuiHelper;
 
 import java.util.ArrayList;
 
@@ -103,7 +104,7 @@ public abstract class Parent extends Node {
 	public void requestLayout() {
 		needsLayout = true;
 		if (isSceneRoot()) {
-			getScene().getGui().setDirtyFlag(DirtyFlag.GUI_CONTENT);
+			GuiHelper.setDirtyFlag(getScene().getGui(), DirtyFlag.GUI_CONTENT);
 		}
 		requestParentLayout();
 	}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
@@ -60,13 +60,13 @@ public abstract class Parent extends Node {
 					if (oldParent != null) {
 						oldParent.getChildren().remove(child);
 					}
-					child.setParent(this);
+					NodeHelper.setParent(child, this);
 				}
 			}
 			if (change.wasRemoved()) {
 				for (Node child : change.getRemovedSubList()) {
 					if (child.getParent() == this) {
-						child.setParent(null);
+						NodeHelper.setParent(child, null);
 					}
 				}
 			}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -175,11 +175,11 @@ public class Scene {
 			return;
 		}
 		if (this.root != null) {
-			this.root.setScene(null);
+			NodeHelper.setScene(this.root, null);
 		}
 		this.root = root;
 		if (root != null) {
-			root.setScene(this);
+			NodeHelper.setScene(root, this);
 		}
 	}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -39,6 +39,15 @@ import java.util.ArrayList;
  */
 public class Scene {
 
+	static {
+		SceneHelper.setSceneAccessor(new SceneHelper.SceneAccessor() {
+			@Override
+			public void setGui(Scene scene, Gui gui) {
+				scene.setGui(gui);
+			}
+		});
+	}
+
 	private final ContextDataHolder dataHolder = new ContextDataHolder();
 
 	private Gui gui;
@@ -87,13 +96,11 @@ public class Scene {
 
 	/**
 	 * Sets the GUI that this scene is attached to.
-	 * <b>This method is part of the internal API and should not be called by users.</b>
-	 * If you want to attach a scene to a GUI, use methods provided by the respective gui class.
 	 *
 	 * @param gui the GUI that this scene is attached to
 	 * @since 2.0.0
 	 */
-	public void setGui(Gui gui) {
+	private void setGui(Gui gui) {
 		this.gui = gui;
 	}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/SceneHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/SceneHelper.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene;
 
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/SceneHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/SceneHelper.java
@@ -1,0 +1,42 @@
+package io.github.somesourcecode.someguiapi.scene;
+
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+
+/**
+ * A helper class for scenes to access internal methods.
+ *
+ * @since 2.0.0
+ */
+public class SceneHelper {
+
+	private static SceneAccessor sceneAccessor;
+
+	private SceneHelper() {
+
+	}
+
+	public static void setGui(Scene scene, Gui gui) {
+		sceneAccessor.setGui(scene, gui);
+	}
+
+	public static void setSceneAccessor(final SceneAccessor newAccessor) {
+		if (sceneAccessor != null) {
+			throw new IllegalStateException();
+		}
+		sceneAccessor = newAccessor;
+	}
+
+	public static SceneAccessor getSceneAccessor() {
+		if (sceneAccessor == null) {
+			throw new IllegalStateException();
+		}
+		return sceneAccessor;
+	}
+
+	public interface SceneAccessor {
+
+		void setGui(Scene scene, Gui gui);
+
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -23,10 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene.gui;
 
-import io.github.somesourcecode.someguiapi.scene.DirtyFlag;
-import io.github.somesourcecode.someguiapi.scene.Parent;
-import io.github.somesourcecode.someguiapi.scene.Pixel;
-import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.*;
 import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
@@ -195,11 +192,11 @@ public class ChestGui extends Gui implements InventoryHolder {
 			return;
 		}
 		if (this.scene != null) {
-			this.scene.setGui(null);
+			SceneHelper.setGui(this.scene, null);
 		}
 		this.scene = scene;
 		if (scene != null) {
-			scene.setGui(this);
+			SceneHelper.setGui(scene, this);
 		}
 		setDirtyFlag(DirtyFlag.GUI_CONTENT);
 		update();

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -39,6 +39,25 @@ import java.util.List;
  */
 public abstract class Gui {
 
+	static {
+		GuiHelper.setGuiAccessor(new GuiHelper.GuiAccessor() {
+			@Override
+			public void setDirtyFlag(Gui gui, DirtyFlag flag) {
+				gui.setDirtyFlag(flag);
+			}
+
+			@Override
+			public void clearDirtyFlag(Gui gui, DirtyFlag flag) {
+				gui.clearDirtyFlag(flag);
+			}
+
+			@Override
+			public void clearDirtyFlags(Gui gui) {
+				gui.clearDirtyFlags();
+			}
+		});
+	}
+
 	protected final ContextDataHolder dataHolder = new ContextDataHolder();
 
 	protected final EnumSet<DirtyFlag> dirtyFlags = EnumSet.noneOf(DirtyFlag.class);
@@ -55,26 +74,62 @@ public abstract class Gui {
 		return dataHolder;
 	}
 
+	/**
+	 * Returns a set of dirty flags that indicate which
+	 * parts of the GUI need to be updated.
+	 *
+	 * @return the dirty flags
+	 * @since 2.0.0
+	 */
 	public EnumSet<DirtyFlag> getDirtyFlags() {
 		return EnumSet.copyOf(dirtyFlags);
 	}
 
-	public final void setDirtyFlag(DirtyFlag flag) {
+	/**
+	 * Sets the specified dirty flag.
+	 *
+	 * @param flag the dirty flag
+	 * @since 2.0.0
+	 */
+	protected void setDirtyFlag(DirtyFlag flag) {
 		dirtyFlags.add(flag);
 	}
 
-	public final void clearDirtyFlag(DirtyFlag flag) {
+	/**
+	 * Clears the specified dirty flag.
+	 *
+	 * @param flag the dirty flag
+	 * @since 2.0.0
+	 */
+	protected void clearDirtyFlag(DirtyFlag flag) {
 		dirtyFlags.remove(flag);
 	}
 
-	public final void clearDirtyFlags() {
+	/**
+	 * Clears all dirty flags.
+	 * @since 2.0.0
+	 */
+	protected void clearDirtyFlags() {
 		dirtyFlags.clear();
 	}
 
+	/**
+	 * Returns whether this GUI is dirty.
+	 *
+	 * @return whether this GUI is dirty
+	 * @since 2.0.0
+	 */
 	public final boolean isDirty() {
 		return !dirtyFlags.isEmpty();
 	}
 
+	/**
+	 * Returns whether the specified dirty flag is set.
+	 *
+	 * @param flag the dirty flag
+	 * @return whether the dirty flag is set
+	 * @since 2.0.0
+	 */
 	public final boolean isDirty(DirtyFlag flag) {
 		return dirtyFlags.contains(flag);
 	}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/GuiHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/GuiHelper.java
@@ -1,0 +1,54 @@
+package io.github.somesourcecode.someguiapi.scene.gui;
+
+import io.github.somesourcecode.someguiapi.scene.DirtyFlag;
+
+/**
+ * A helper class for GUIs to access internal methods.
+ *
+ * @since 2.0.0
+ */
+public class GuiHelper {
+
+	private static GuiAccessor guiAccessor;
+
+	private GuiHelper() {
+
+	}
+
+	public static void setGuiAccessor(final GuiAccessor newAccessor) {
+		if (guiAccessor != null) {
+			throw new IllegalStateException();
+		}
+		guiAccessor = newAccessor;
+	}
+
+	public static GuiAccessor getGuiAccessor() {
+		if (guiAccessor == null) {
+			throw new IllegalStateException();
+		}
+		return guiAccessor;
+	}
+
+	public static void setDirtyFlag(Gui gui, DirtyFlag flag) {
+		guiAccessor.setDirtyFlag(gui, flag);
+	}
+
+	public static void clearDirtyFlag(Gui gui, DirtyFlag flag) {
+		guiAccessor.clearDirtyFlag(gui, flag);
+	}
+
+	public static void clearDirtyFlags(Gui gui) {
+		guiAccessor.clearDirtyFlags(gui);
+	}
+
+	public interface GuiAccessor {
+
+		void setDirtyFlag(Gui gui, DirtyFlag flag);
+
+		void clearDirtyFlag(Gui gui, DirtyFlag flag);
+
+		void clearDirtyFlags(Gui gui);
+
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/GuiHelper.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/GuiHelper.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.DirtyFlag;


### PR DESCRIPTION
### Description

Hide internal API methods in accordance with #6.

This is achieved by introducing helper classes. These classes are named after the classes they assist, followed by the `Helper` prefix. New internal methods must be added to the corresponding interfaces, and new helper classes must adhere to this naming convention.

### Examples
```java
NodeHelper.setScene(node, scene);
SceneHelper.setGui(scene, gui);
GuiHelper.setDirtyFlag(gui, flag);
```

Note that while the methods can still technically be called by the application, they can no longer be called directly on the respective classes.