### PR TITLE
Implement node ids

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/GuiItem.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/GuiItem.java
@@ -255,6 +255,7 @@ public class GuiItem extends Node {
 
 		private int layoutX;
 		private int layoutY;
+		private String id;
 
 		private Consumer<NodeClickContext> onClick;
 		private Consumer<NodeClickContext> onLeftClick;
@@ -315,6 +316,18 @@ public class GuiItem extends Node {
 		 */
 		public Builder atY(int y) {
 			layoutY = y;
+			return this;
+		}
+
+		/**
+		 * Sets the id of the item.
+		 *
+		 * @param id the id
+		 * @return the builder for method chaining
+		 * @since 2.0.0
+		 */
+		public Builder withId(String id) {
+			this.id = id;
 			return this;
 		}
 
@@ -470,6 +483,7 @@ public class GuiItem extends Node {
 			GuiItem item = new GuiItem();
 			item.setMaterial(material);
 			item.setTitle(title);
+			item.setId(id);
 			item.setLore(lore);
 			item.setIndex(index);
 			item.setGlow(glow);

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -174,7 +174,7 @@ public abstract class Node {
 	 * @since 2.0.0
 	 */
 	public Node lookup(String selector) {
-		if (selector == null) {
+		if (selector == null || id == null) {
 			return null;
 		}
 		if (selector.equals("#" + id)) {

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -154,12 +154,33 @@ public abstract class Node {
 
 	/**
 	 * Sets the id of this node.
+	 * While the id should be unique, this uniqueness not enforced.
 	 *
 	 * @param id the id of this node
 	 * @since 2.0.0
 	 */
 	public final void setId(String id) {
 		this.id = id;
+	}
+
+	/**
+	 * Finds this {@code Node} or the first sub-node by the given selector.
+	 * <p>
+	 * For example, to find a node with the id "my-node", the method can be
+	 * used like this: {@code scene.lookup("#my-node")}.
+	 *
+	 * @param selector the selector
+	 * @return the first node that matches the selector, null if none is found
+	 * @since 2.0.0
+	 */
+	public Node lookup(String selector) {
+		if (selector == null) {
+			return null;
+		}
+		if (selector.equals("#" + id)) {
+			return this;
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -78,6 +78,8 @@ public abstract class Node {
 	private Scene scene;
 	private Parent parent;
 
+	private String id;
+
 	private int layoutX;
 	private int layoutY;
 
@@ -138,6 +140,26 @@ public abstract class Node {
 	 */
 	private void setParent(Parent parent) {
 		this.parent = parent;
+	}
+
+	/**
+	 * Returns the id of this node.
+	 *
+	 * @return the id of this node
+	 * @since 2.0.0
+	 */
+	public final String getId() {
+		return id;
+	}
+
+	/**
+	 * Sets the id of this node.
+	 *
+	 * @param id the id of this node
+	 * @since 2.0.0
+	 */
+	public final void setId(String id) {
+		this.id = id;
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -25,6 +25,7 @@ package io.github.somesourcecode.someguiapi.scene;
 
 import io.github.somesourcecode.someguiapi.scene.action.NodeClickContext;
 
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -181,6 +182,48 @@ public abstract class Node {
 			return this;
 		}
 		return null;
+	}
+
+	/**
+	 * Finds all nodes that match the given selector.
+	 * <p>
+	 * For example, to find all nodes with the class "my-class", the method can be
+	 * used like this: {@code scene.lookupAll(".my-class")}.
+	 *
+	 * @param selector the selector
+	 * @return a set of nodes that match the selector. This is always non-null and unmodifiable.
+	 * @since 2.0.0
+	 */
+	public Set<Node> lookupAll(String selector) {
+		final Set<Node> empty = Collections.emptySet();
+		if (selector == null) {
+			return empty;
+		}
+		Set<Node> results = lookupAll(selector, null);
+		return results == null ? empty : Collections.unmodifiableSet(results);
+	}
+
+	/**
+	 * Used by Node and Parent to traverse the scene graph to find
+	 * all nodes that match the given selector.
+	 *
+	 * @param selector the selector
+	 * @param results the results
+	 * @return a set of nodes that match the selector; null if none is found
+	 * @since 2.0.0
+	 */
+	protected Set<Node> lookupAll(String selector, Set<Node> results) {
+		if (selector == null || id == null) {
+			return results;
+		}
+
+		if (selector.equals("#" + id)) {
+			if (results == null) {
+				results = new HashSet<>();
+			}
+			results.add(this);
+		}
+		return results;
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
@@ -28,6 +28,8 @@ import io.github.somesourcecode.someguiapi.collections.ObservableListBase;
 import io.github.somesourcecode.someguiapi.scene.gui.GuiHelper;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The base class for all nodes that can have children.
@@ -107,6 +109,22 @@ public abstract class Parent extends Node {
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>
+	 * Note: This method should never create the result set. That should be
+	 * done by the Node class implementation.
+	 */
+	@Override
+	protected Set<Node> lookupAll(String selector, Set<Node> results) {
+		results = super.lookupAll(selector, results);
+		for (Node child : children) {
+			results = child.lookupAll(selector, results);
+		}
+		return results;
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Parent.java
@@ -95,6 +95,20 @@ public abstract class Parent extends Node {
 		return getParent() == null && getScene() != null;
 	}
 
+	@Override
+	public Node lookup(String selector) {
+		Node result = super.lookup(selector);
+		if (result == null) {
+			for (Node child : children) {
+				result = child.lookup(selector);
+				if (result != null) {
+					return result;
+				}
+			}
+		}
+		return result;
+	}
+
 	/**
 	 * Requests a layout update for this parent.
 	 * Layout will be applied on the next layout pass.

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -201,6 +201,7 @@ public class Scene {
 	 * @return the first node on the scene graph that matches the selector,
 	 * null if no node matches the selector
 	 * @see Node#lookup(String)
+	 * @since 2.0.0
 	 */
 	public Node lookup(String selector) {
 		if (root == null) {
@@ -216,6 +217,7 @@ public class Scene {
 	 * @param selector the selector
 	 * @return a set of nodes that match the selector. This is always non-null and unmodifiable.
 	 * @see Node#lookupAll(String)
+	 * @since 2.0.0
 	 */
 	public Set<Node> lookupAll(String selector) {
 		if (root == null) {

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -191,6 +191,23 @@ public class Scene {
 	}
 
 	/**
+	 * Looks for any node in the scene that matches the given selector.
+	 * If multiple nodes are found, the first one found is returned.
+	 * If no node is found, null is returned.
+	 *
+	 * @param selector the selector
+	 * @return the first node on the scene graph that matches the selector,
+	 * null if no node matches the selector
+	 * @see Node#lookup(String)
+	 */
+	public Node lookup(String selector) {
+		if (root == null) {
+			return null;
+		}
+		return root.lookup(selector);
+	}
+
+	/**
 	 * Returns the background of the scene.
 	 *
 	 * @return the background of the scene

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -28,6 +28,8 @@ import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * The Scene class is the container for all content in a scene graph.
@@ -205,6 +207,21 @@ public class Scene {
 			return null;
 		}
 		return root.lookup(selector);
+	}
+
+	/**
+	 * Looks for all nodes in the scene that match the given selector.
+	 * If no node is found, an empty set is returned.
+	 *
+	 * @param selector the selector
+	 * @return a set of nodes that match the selector. This is always non-null and unmodifiable.
+	 * @see Node#lookupAll(String)
+	 */
+	public Set<Node> lookupAll(String selector) {
+		if (root == null) {
+			return Collections.emptySet();
+		}
+		return root.lookupAll(selector);
 	}
 
 	/**


### PR DESCRIPTION
### Description

Introduces node ids as requested in #2. Every `Node` can now be assigned a String id. This id can be unique, although this uniqueness is not enforced.
To find a node, `Node#lookup(String selector)` can be used, which looks for the first node matching the selector. Note that in order to find a node by its id, the id has to be prefixed with a hashtag (`#`).
To retrieve a set of all `Node`s matching the selector `Node#lookupAll(String selector)` can be used.
For convenience, these methods also exist in the `Scene` class, where they are identical to calling them on the scene root.

The prefix is technically not needed, but was still implemented so that selectors can be expanded in the future to not just be limited to ids.

### Code Example

```java
// Assign an id:
node.setId("my-id");
// Lookup by an id:
Node result = scene.lookup("#my-id");
// Lookup all nodes with the id:
Set<Node> results = scene.lookupAll("#my-id");
```