### PR TITLE
Refactor package structure

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi;
 
-import io.github.somesourcecode.someguiapi.scene.action.NodeClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.gui.ChestGui;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/GuiItem.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/GuiItem.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.scene.action.NodeClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.lore.Lore;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.scene.action.NodeClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 
 import java.util.*;
 import java.util.function.Consumer;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Pixel.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Pixel.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import io.github.somesourcecode.someguiapi.scene.lore.Lore;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.scene.action.NodeClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.action;
+package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import org.bukkit.entity.HumanEntity;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.action;
+package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -24,7 +24,7 @@
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.*;
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/FlowPane.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/FlowPane.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.pane;
+package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.scene.Node;
 import io.github.somesourcecode.someguiapi.util.Orientation;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/FlowPane.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/FlowPane.java
@@ -24,7 +24,7 @@
 package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.scene.Node;
-import io.github.somesourcecode.someguiapi.util.Orientation;
+import io.github.somesourcecode.someguiapi.scene.util.Orientation;
 
 /**
  * A layout pane that arranges its children in a flow, wrapping at the pane's bounds.

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/HBox.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/HBox.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.pane;
+package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.scene.Node;
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Pane.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Pane.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.pane;
+package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.collections.ObservableList;
 import io.github.somesourcecode.someguiapi.scene.Node;
@@ -34,9 +34,9 @@ import io.github.somesourcecode.someguiapi.scene.Node;
  * Layout panes should extend this class.
  * <p>
  * For more complex layouts, use different panes, e.g.
- * {@link io.github.somesourcecode.someguiapi.scene.pane.VBox},
- * {@link io.github.somesourcecode.someguiapi.scene.pane.HBox},
- * {@link io.github.somesourcecode.someguiapi.scene.pane.FlowPane}, etc.
+ * {@link io.github.somesourcecode.someguiapi.scene.layout.VBox},
+ * {@link io.github.somesourcecode.someguiapi.scene.layout.HBox},
+ * {@link io.github.somesourcecode.someguiapi.scene.layout.FlowPane}, etc.
  *
  * @since 1.0.0
  */

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Region.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Region.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene.layout;
 
-import io.github.somesourcecode.someguiapi.util.Insets;
+import io.github.somesourcecode.someguiapi.scene.util.Insets;
 import io.github.somesourcecode.someguiapi.scene.Parent;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Region.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/Region.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.pane;
+package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.util.Insets;
 import io.github.somesourcecode.someguiapi.scene.Parent;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/VBox.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/layout/VBox.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.scene.pane;
+package io.github.somesourcecode.someguiapi.scene.layout;
 
 import io.github.somesourcecode.someguiapi.scene.Node;
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/ContextParagraph.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/ContextParagraph.java
@@ -1,6 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.lore;
 
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 
 import java.util.Collections;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/Lore.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/Lore.java
@@ -1,6 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.lore;
 
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/Paragraph.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/Paragraph.java
@@ -1,6 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.lore;
 
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/ReloadableParagraph.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/lore/ReloadableParagraph.java
@@ -1,6 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.lore;
 
-import io.github.somesourcecode.someguiapi.scene.action.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 
 /**
  * Represents a paragraph whose content depends on the context in which it is rendered.

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/util/Insets.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/util/Insets.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.util;
+package io.github.somesourcecode.someguiapi.scene.util;
 
 /**
  * Represents the distance from the edges of a container to its content.

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/util/Orientation.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/util/Orientation.java
@@ -21,7 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.somesourcecode.someguiapi.util;
+package io.github.somesourcecode.someguiapi.scene.util;
 
 /**
  * Represents the orientation of a control or layout.


### PR DESCRIPTION
Renames some packages and moves some classes for more clarity.

### Changes

- Rename package `panes` -> `layout`
- Rename package `action` -> `context`
- Move `Insets` and `Orientation` from `...util` to `...scene.util`