### PR TITLE
More events

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -52,9 +52,12 @@ public class GuiListener implements Listener {
 		event.setCancelled(true);
 
 		final GuiArea area = event.getClickedInventory() == null ? GuiArea.OUTSIDE : event.getClickedInventory().equals(gui.getInventory()) ? GuiArea.TOP : GuiArea.BOTTOM;
+		final GuiClickContext guiClickContext = new GuiClickContext(gui, gui.getScene(), area, event.getClick(), event.getHotbarButton(), event.getWhoClicked());
+
+		gui.fireOnClick(guiClickContext);
 
 		if (area == GuiArea.OUTSIDE) {
-			gui.fireOnOutsideClick(new GuiClickContext(gui, gui.getScene(), area, event.getClick(), event.getHotbarButton(), event.getWhoClicked()));
+			gui.fireOnOutsideClick(guiClickContext);
 			return;
 		}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -29,10 +29,12 @@ import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.gui.ChestGui;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 
 /**
  * A listener that listens for GUI interactions.
@@ -70,8 +72,14 @@ public class GuiListener implements Listener {
 			return;
 		}
 
-		if (!gui.isUpdating() && gui.getOnClose() != null) {
-			gui.fireOnClose(new GuiCloseContext(gui, gui instanceof ChestGui chestGui ? chestGui.getScene() : null, event.getPlayer()));
+		if (!gui.isUpdating()) {
+			GuiCloseContext context = new GuiCloseContext(gui, gui instanceof ChestGui chestGui ? chestGui.getScene() : null, event.getPlayer());
+			gui.fireOnClose(context);
+
+			if (context.isCanceled()) {
+				Bukkit.getScheduler().runTask(JavaPlugin.getProvidingPlugin(GuiListener.class),
+						() -> gui.show(event.getPlayer()));
+			}
 		}
 	}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -23,11 +23,10 @@
 
 package io.github.somesourcecode.someguiapi;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
+import io.github.somesourcecode.someguiapi.scene.context.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.context.GuiClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.GuiCloseContext;
 import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
-import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.gui.ChestGui;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.Bukkit;

--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -49,18 +49,14 @@ public class GuiListener implements Listener {
 		event.setCancelled(true);
 
 		if (event.getClickedInventory() == null) {
-			if (gui.getOnOutsideClick() != null) {
-				gui.getOnOutsideClick().accept(new GuiClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked()));
-			}
+			gui.fireOnOutsideClick(new GuiClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked()));
 			return;
 		}
 
 		int slotX = event.getSlot() % 9;
 		int slotY = event.getSlot() / 9;
 
-		if (gui.getOnGuiClick() != null && event.getClickedInventory().equals(gui.getInventory())) {
-			gui.getOnGuiClick().accept(new GuiSlotClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
-		}
+		gui.fireOnGuiClick(new GuiSlotClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
 
 		if (gui.getScene() == null) {
 			return;
@@ -75,9 +71,7 @@ public class GuiListener implements Listener {
 		}
 
 		if (!gui.isUpdating() && gui.getOnClose() != null) {
-			GuiCloseContext guiCloseContext = new GuiCloseContext(gui, gui instanceof ChestGui chestGui ? chestGui.getScene() : null, event.getPlayer());
-			gui.getOnClose().accept(guiCloseContext);
-
+			gui.fireOnClose(new GuiCloseContext(gui, gui instanceof ChestGui chestGui ? chestGui.getScene() : null, event.getPlayer()));
 		}
 	}
 

--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -60,10 +60,7 @@ public class GuiListener implements Listener {
 
 		gui.fireOnGuiClick(new GuiSlotClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
 
-		if (gui.getScene() == null) {
-			return;
-		}
-		gui.handleClick(new NodeClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
+		gui.handleClick(event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY);
 	}
 
 	@EventHandler

--- a/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/GuiListener.java
@@ -23,6 +23,7 @@
 
 package io.github.somesourcecode.someguiapi;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.context.GuiClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.GuiCloseContext;
 import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
@@ -50,17 +51,19 @@ public class GuiListener implements Listener {
 		}
 		event.setCancelled(true);
 
-		if (event.getClickedInventory() == null) {
-			gui.fireOnOutsideClick(new GuiClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked()));
+		final GuiArea area = event.getClickedInventory() == null ? GuiArea.OUTSIDE : event.getClickedInventory().equals(gui.getInventory()) ? GuiArea.TOP : GuiArea.BOTTOM;
+
+		if (area == GuiArea.OUTSIDE) {
+			gui.fireOnOutsideClick(new GuiClickContext(gui, gui.getScene(), area, event.getClick(), event.getHotbarButton(), event.getWhoClicked()));
 			return;
 		}
 
-		int slotX = event.getSlot() % 9;
-		int slotY = event.getSlot() / 9;
+		int slotX = event.getRawSlot() % 9;
+		int slotY = event.getRawSlot() / 9;
 
-		gui.fireOnGuiClick(new GuiSlotClickContext(gui, gui.getScene(), event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
+		gui.fireOnGuiClick(new GuiSlotClickContext(gui, gui.getScene(), area, event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY));
 
-		gui.handleClick(event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY);
+		gui.handleClick(area, event.getClick(), event.getHotbarButton(), event.getWhoClicked(), slotX, slotY);
 	}
 
 	@EventHandler

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/GuiArea.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/GuiArea.java
@@ -1,0 +1,14 @@
+package io.github.somesourcecode.someguiapi.collections;
+
+/**
+ * Represents the area inside a GUI.
+ *
+ * @since 2.1.0
+ */
+public enum GuiArea {
+
+	TOP,
+	BOTTOM,
+	OUTSIDE
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Node.java
@@ -23,10 +23,13 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
+import io.github.somesourcecode.someguiapi.scene.context.Context;
 import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
+import org.bukkit.Bukkit;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * The base class for all nodes in the scene graph. A scene graph is a set of tree data structures
@@ -445,6 +448,17 @@ public abstract class Node {
 	}
 
 	/**
+	 * Fires the consumer, set by {@link #setOnClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnClick(NodeClickContext context) {
+		fireCallback(onClick, context, "onClick");
+	}
+
+	/**
 	 * Returns the consumer that is called when the node is left-clicked.
 	 *
 	 * @return the consumer that is called when the node is left-clicked
@@ -462,6 +476,17 @@ public abstract class Node {
 	 */
 	public void setOnLeftClick(Consumer<NodeClickContext> onLeftClick) {
 		this.onLeftClick = onLeftClick;
+	}
+
+	/**
+	 * Fires the consumer, set by {@link #setOnLeftClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnLeftClick(NodeClickContext context) {
+		fireCallback(onLeftClick, context, "onLeftClick");
 	}
 
 	/**
@@ -485,6 +510,17 @@ public abstract class Node {
 	}
 
 	/**
+	 * Fires the consumer, set by {@link #setOnRightClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnRightClick(NodeClickContext context) {
+		fireCallback(onRightClick, context, "onRightClick");
+	}
+
+	/**
 	 * Returns the consumer that is called when the node is shift-clicked.
 	 *
 	 * @return the consumer that is called when the node is shift-clicked
@@ -502,6 +538,17 @@ public abstract class Node {
 	 */
 	public void setOnShiftClick(Consumer<NodeClickContext> onShiftClick) {
 		this.onShiftClick = onShiftClick;
+	}
+
+	/**
+	 * Fires the consumer, set by {@link #setOnShiftClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnShiftClick(NodeClickContext context) {
+		fireCallback(onShiftClick, context, "onShiftClick");
 	}
 
 	/**
@@ -525,6 +572,17 @@ public abstract class Node {
 	}
 
 	/**
+	 * Fires the consumer, set by {@link #setOnHotBarClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnHotBarClick(NodeClickContext context) {
+		fireCallback(onHotBarClick, context, "onHotBarClick");
+	}
+
+	/**
 	 * Returns a {@link Pixel} that should be rendered at the given coordinates.
 	 * The coordinates are relative to this parent's bounds.
 	 *
@@ -545,5 +603,27 @@ public abstract class Node {
 	 * @since 1.0.0
 	 */
 	public abstract Node nodeAt(int x, int y);
+
+	/**
+	 * Calls the given callback with the specified context.
+	 * If the callback throws an exception, the exception is caught and logged.
+	 *
+	 * @param callback the callback
+	 * @param context the context
+	 * @param name the name of the callback
+	 * @param <T> the type of the context
+	 */
+	protected <T extends Context> void fireCallback(Consumer<? super T> callback, T context, String name) {
+		if (callback == null) {
+			return;
+		}
+
+		try {
+			callback.accept(context);
+		} catch (Exception e) {
+			String errorMessage = "An error occurred while calling '" + name + "''";
+			Bukkit.getLogger().log(Level.SEVERE, errorMessage, e);
+		}
+	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Pixel.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Pixel.java
@@ -23,7 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.PixelRenderContext;
 import io.github.somesourcecode.someguiapi.scene.lore.Lore;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
@@ -328,7 +328,7 @@ public class Pixel {
 	 * @return the rendered ItemStack
 	 * @since 2.0.0
 	 */
-	public ItemStack renderItemStack(RenderContext renderContext) {
+	public ItemStack renderItemStack(PixelRenderContext renderContext) {
 		if (isEmpty()) {
 			return null;
 		}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -113,7 +113,7 @@ public class Scene {
 	 * @param context the click context
 	 * @since 1.0.0
 	 */
-	public void fireOnClick(NodeClickContext context) {
+	public void handleClick(NodeClickContext context) {
 		if (root == null) {
 			return;
 		}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -23,6 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.context.Context;
 import io.github.somesourcecode.someguiapi.scene.context.GuiRenderContext;
 import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
@@ -120,6 +121,7 @@ public class Scene {
 	 * Fires the onClick event for the node at the given coordinates.
 	 * The listeners a called for the clicked node and all of its parents, respectively.
 	 *
+	 * @param area the area of the click
 	 * @param clickType the click type
 	 * @param hotbarButton the hot bar button
 	 * @param whoClicked the human entity that clicked
@@ -127,7 +129,7 @@ public class Scene {
 	 * @param y the y coordinate of the slot
 	 * @since 2.1.0
 	 */
-	public void handleClick(ClickType clickType, int hotbarButton, HumanEntity whoClicked, int x, int y) {
+	public void handleClick(GuiArea area, ClickType clickType, int hotbarButton, HumanEntity whoClicked, int x, int y) {
 		if (root == null) {
 			return;
 		}
@@ -155,7 +157,7 @@ public class Scene {
 			parent = parent.getParent();
 		}
 
-		NodeClickContext context = new NodeClickContext(gui, this, clickType, hotbarButton, whoClicked, x, y, clickedNode, clickedNode);
+		NodeClickContext context = new NodeClickContext(gui, this, area, clickType, hotbarButton, whoClicked, x, y, clickedNode, clickedNode);
 
 		for (Node node : nodeBranch) {
 			context = context.copyFor(node);

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -147,9 +147,10 @@ public class Scene {
 			parent = parent.getParent();
 		}
 
-		NodeClickContext context = new NodeClickContext(gui, this, clickType, hotbarButton, whoClicked, x, y, clickedNode);
+		NodeClickContext context = new NodeClickContext(gui, this, clickType, hotbarButton, whoClicked, x, y, clickedNode, clickedNode);
 
 		for (Node node : nodeBranch) {
+			context = context.copyFor(node);
 			node.fireOnClick(context);
 			if (context.isLeftClick()) {
 				node.fireOnLeftClick(context);

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -145,20 +145,18 @@ public class Scene {
 		}
 
 		for (Node node : nodeBranch) {
-			if (node.getOnClick() != null) {
-				node.getOnClick().accept(context);
+			node.fireOnClick(context);
+			if (context.isLeftClick()) {
+				node.fireOnLeftClick(context);
 			}
-			if (node.getOnLeftClick() != null && context.isLeftClick()) {
-				node.getOnLeftClick().accept(context);
+			if (context.isRightClick()) {
+				node.fireOnRightClick(context);
 			}
-			if (node.getOnRightClick() != null && context.isRightClick()) {
-				node.getOnRightClick().accept(context);
+			if (context.isShiftClick()) {
+				node.fireOnShiftClick(context);
 			}
-			if (node.getOnShiftClick() != null && context.isShiftClick()) {
-				node.getOnShiftClick().accept(context);
-			}
-			if (node.getOnHotBarClick() != null && context.isHotBarClick()) {
-				node.getOnHotBarClick().accept(context);
+			if (context.isHotBarClick()) {
+				node.fireOnHotBarClick(context);
 			}
 		}
 	}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -23,10 +23,9 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
+import io.github.somesourcecode.someguiapi.scene.context.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.context.Context;
 import io.github.somesourcecode.someguiapi.scene.context.GuiRenderContext;
-import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -23,15 +23,21 @@
 
 package io.github.somesourcecode.someguiapi.scene;
 
+import io.github.somesourcecode.someguiapi.scene.context.Context;
+import io.github.somesourcecode.someguiapi.scene.context.GuiRenderContext;
+import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.ClickType;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * The Scene class is the container for all content in a scene graph.
@@ -58,6 +64,8 @@ public class Scene {
 
 	private Parent root;
 	private Background background;
+
+	private Consumer<GuiRenderContext> onRender;
 
 	/**
 	 * Constructs a new empty scene.
@@ -248,6 +256,59 @@ public class Scene {
 	 */
 	public void setBackground(Background background) {
 		this.background = background;
+	}
+
+	/**
+	 * Returns the consumer that is called when the scene is rendered.
+	 *
+	 * @return the consumer that is called when the scene is rendered
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiRenderContext> getOnRender() {
+		return onRender;
+	}
+
+	/**
+	 * Sets the consumer that is called when the scene is rendered.
+	 *
+	 * @param onRender the consumer that is called when the scene is rendered
+	 * @since 2.1.0
+	 */
+	public void setOnRender(Consumer<GuiRenderContext> onRender) {
+		this.onRender = onRender;
+	}
+
+	/**
+	 * Fires the consumer, set by {@link #setOnRender(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnRender(GuiRenderContext context) {
+		fireCallback(onRender, context, "onRender");
+	}
+
+	/**
+	 * Calls the given callback with the specified context.
+	 * If the callback throws an exception, the exception is caught and logged.
+	 *
+	 * @param callback the callback
+	 * @param context the context
+	 * @param name the name of the callback
+	 * @param <T> the type of the context
+	 */
+	protected <T extends Context> void fireCallback(Consumer<? super T> callback, T context, String name) {
+		if (callback == null) {
+			return;
+		}
+
+		try {
+			callback.accept(context);
+		} catch (Exception e) {
+			String errorMessage = "An error occurred while calling '" + name + "''";
+			Bukkit.getLogger().log(Level.SEVERE, errorMessage, e);
+		}
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/Scene.java
@@ -26,6 +26,8 @@ package io.github.somesourcecode.someguiapi.scene;
 import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.ClickType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -110,23 +112,24 @@ public class Scene {
 	 * Fires the onClick event for the node at the given coordinates.
 	 * The listeners a called for the clicked node and all of its parents, respectively.
 	 *
-	 * @param context the click context
-	 * @since 1.0.0
+	 * @param clickType the click type
+	 * @param hotbarButton the hot bar button
+	 * @param whoClicked the human entity that clicked
+	 * @param x the x coordinate of the slot
+	 * @param y the y coordinate of the slot
+	 * @since 2.1.0
 	 */
-	public void handleClick(NodeClickContext context) {
+	public void handleClick(ClickType clickType, int hotbarButton, HumanEntity whoClicked, int x, int y) {
 		if (root == null) {
 			return;
 		}
-
-		int x = context.getSlotX();
-		int y = context.getSlotY();
 
 		final int localX = x - root.getLayoutX();
 		final int localY = y - root.getLayoutY();
 
 		final ArrayList<Node> nodeBranch = new ArrayList<>();
 
-		Node clickedNode = root.nodeAt(localX, localY);
+		final Node clickedNode = root.nodeAt(localX, localY);
 		if (clickedNode == null) {
 			return;
 		}
@@ -143,6 +146,8 @@ public class Scene {
 			clickedLocalY += parent.getLayoutY();
 			parent = parent.getParent();
 		}
+
+		NodeClickContext context = new NodeClickContext(gui, this, clickType, hotbarButton, whoClicked, x, y, clickedNode);
 
 		for (Node node : nodeBranch) {
 			node.fireOnClick(context);

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Cancelable.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Cancelable.java
@@ -1,0 +1,36 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+/**
+ * A cancelable event.
+ *
+ * @since 2.1.0
+ */
+public interface Cancelable {
+
+	/**
+	 * Returns the cancellation state of the event.
+	 *
+	 * @return whether the event is canceled
+	 * @since 2.1.0
+	 */
+	boolean isCanceled();
+
+	/**
+	 * Sets the cancellation state of the event.
+	 *
+	 * @param canceled the cancellation state
+	 * @since 2.1.0
+	 */
+	void setCanceled(boolean canceled);
+
+	/**
+	 * Cancels the event. This is a shorthand for {@code setCanceled(true)}.
+	 *
+	 * @see #setCanceled(boolean)
+	 * @since 2.1.0
+	 */
+	default void cancel() {
+		setCanceled(true);
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Cancelable.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Cancelable.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Consumable.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Consumable.java
@@ -1,0 +1,27 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+/**
+ * A consumable event.
+ *
+ * @since 2.1.0
+ */
+public interface Consumable {
+
+	/**
+	 * Check if the event was consumed.
+	 *
+	 * @return if the event was consumed
+	 * @since 2.1.0
+	 */
+	boolean isConsumed();
+
+	/**
+	 * Consumes the click.
+	 * Once a click has been consumed, {@link #isConsumed()} will return {@code true}.
+	 *
+	 * @see #isConsumed()
+	 * @since 2.1.0
+	 */
+	void consume();
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Consumable.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Consumable.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Context.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Context.java
@@ -1,0 +1,8 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+/**
+ * A tag interface for contexts.
+ */
+public interface Context {
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Context.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/Context.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiArea.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiArea.java
@@ -1,4 +1,4 @@
-package io.github.somesourcecode.someguiapi.collections;
+package io.github.somesourcecode.someguiapi.scene.context;
 
 /**
  * Represents the area inside a GUI.

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiArea.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiArea.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 /**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
@@ -1,5 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;
@@ -12,6 +13,8 @@ import org.bukkit.event.inventory.ClickType;
  */
 public class GuiClickContext extends GuiContext {
 
+	private final GuiArea area;
+
 	private final ClickType type;
 	private final int hotBarButton;
 
@@ -22,16 +25,72 @@ public class GuiClickContext extends GuiContext {
 	 *
 	 * @param gui the GUI
 	 * @param scene the scene
+	 * @param area the area of the click
 	 * @param type the click type
 	 * @param hotBarButton the hot bar button
 	 * @param whoClicked the human entity that
 	 * @since 2.1.0
 	 */
-	public GuiClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked) {
+	public GuiClickContext(Gui gui, Scene scene, GuiArea area, ClickType type, int hotBarButton, HumanEntity whoClicked) {
 		super(gui, scene);
+		this.area = area;
 		this.type = type;
 		this.hotBarButton = hotBarButton;
 		this.whoClicked = whoClicked;
+	}
+
+	/**
+	 * Returns the area of the click.
+	 *
+	 * @return the area of the click
+	 * @since 2.1.0
+	 */
+	public GuiArea getArea() {
+		return area;
+	}
+
+	/**
+	 * Returns whether the click was a click
+	 * inside the top area of the GUI.
+	 *
+	 * @return whether the click was a click
+	 * @since 2.1.0
+	 */
+	public boolean isTopClick() {
+		return area == GuiArea.TOP;
+	}
+
+	/**
+	 * Returns whether the click was a click
+	 * inside the bottom area of the GUI.
+	 *
+	 * @return whether the click was a click
+	 * @since 2.1.0
+	 */
+	public boolean isBottomClick() {
+		return area == GuiArea.BOTTOM;
+	}
+
+	/**
+	 * Returns whether the click was a click
+	 * outside the area of the GUI.
+	 *
+	 * @return whether the click was a click
+	 * @since 2.1.0
+	 */
+	public boolean isOutsideClick() {
+		return area == GuiArea.OUTSIDE;
+	}
+
+	/**
+	 * Returns whether the click was a click
+	 * inside the area of the GUI.
+	 *
+	 * @return whether the click was a click
+	 * @since 2.1.0
+	 */
+	public boolean isGuiClick() {
+		return area != GuiArea.OUTSIDE;
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
@@ -1,0 +1,108 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.ClickType;
+
+/**
+ * The context of a click event in a GUI.
+ *
+ * @since 2.1.0
+ */
+public class GuiClickContext extends GuiContext {
+
+	private final ClickType type;
+	private final int hotBarButton;
+
+	private final HumanEntity whoClicked;
+
+	/**
+	 * Constructs a new click context.
+	 *
+	 * @param gui the GUI
+	 * @param scene the scene
+	 * @param type the click type
+	 * @param hotBarButton the hot bar button
+	 * @param whoClicked the human entity that
+	 * @since 2.1.0
+	 */
+	public GuiClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked) {
+		super(gui, scene);
+		this.type = type;
+		this.hotBarButton = hotBarButton;
+		this.whoClicked = whoClicked;
+	}
+
+	/**
+	 * Returns the click type.
+	 *
+	 * @return the click type
+	 * @since 2.1.0
+	 */
+	public ClickType getType() {
+		return type;
+	}
+
+	/**
+	 * Returns whether the click was a left click.
+	 *
+	 * @return whether the click was a left click
+	 * @since 2.1.0
+	 */
+	public boolean isLeftClick() {
+		return type.isLeftClick();
+	}
+
+	/**
+	 * Returns whether the click was a right click.
+	 *
+	 * @return whether the click was a right click
+	 * @since 2.1.0
+	 */
+	public boolean isRightClick() {
+		return type.isRightClick();
+	}
+
+	/**
+	 * Returns whether the click was a shift click.
+	 *
+	 * @return whether the click was a shift click
+	 * @since 2.1.0
+	 */
+	public boolean isShiftClick() {
+		return type.isShiftClick();
+	}
+
+	/**
+	 * Returns whether the click was a hot bar click.
+	 *
+	 * @return whether the click was a hot bar click
+	 * @since 2.1.0
+	 */
+	public boolean isHotBarClick() {
+		return hotBarButton != -1;
+	}
+
+	/**
+	 * Returns the hot bar button.
+	 *
+	 * @return the hot bar button, or -1 if
+	 * the click was not a hot bar click
+	 * @since 2.1.0
+	 */
+	public int getHotBarButton() {
+		return hotBarButton;
+	}
+
+	/**
+	 * Returns the human entity that clicked the GUI.
+	 *
+	 * @return the human entity that clicked the GUI
+	 * @since 2.1.0
+	 */
+	public HumanEntity getWhoClicked() {
+		return whoClicked;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
@@ -1,6 +1,5 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiClickContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
@@ -9,9 +9,11 @@ import org.bukkit.entity.HumanEntity;
  *
  * @since 2.1.0
  */
-public class GuiCloseContext extends GuiContext {
+public class GuiCloseContext extends GuiContext implements Cancelable {
 
 	private final HumanEntity player;
+
+	private boolean canceled;
 
 	/**
 	 * Constructs a new GUI close context.
@@ -33,6 +35,16 @@ public class GuiCloseContext extends GuiContext {
 	 */
 	public HumanEntity getPlayer() {
 		return player;
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return canceled;
+	}
+
+	@Override
+	public void setCanceled(boolean canceled) {
+		this.canceled = canceled;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
@@ -1,0 +1,38 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.entity.HumanEntity;
+
+/**
+ * Represents the context of a GUI close event.
+ *
+ * @since 2.1.0
+ */
+public class GuiCloseContext extends GuiContext {
+
+	private final HumanEntity player;
+
+	/**
+	 * Constructs a new GUI close context.
+	 *
+	 * @param gui the GUI
+	 * @param scene the scene
+	 * @param player the player
+	 * @since 2.1.0
+	 */
+	public GuiCloseContext(Gui gui, Scene scene, HumanEntity player) {
+		super(gui, scene);
+		this.player = player;
+	}
+
+	/**
+	 * Returns the human entity whose GUI is being closed.
+	 *
+	 * @return the human entity
+	 */
+	public HumanEntity getPlayer() {
+		return player;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiCloseContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
@@ -8,7 +8,7 @@ import io.github.somesourcecode.someguiapi.scene.gui.Gui;
  *
  * @since 2.1.0
  */
-public class GuiContext {
+public class GuiContext implements Context {
 
 	private final Gui gui;
 	private final Scene scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
@@ -1,0 +1,48 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+
+/**
+ * The basic context for a GUI.
+ *
+ * @since 2.1.0
+ */
+public class GuiContext {
+
+	private final Gui gui;
+	private final Scene scene;
+
+	/**
+	 * Constructs a new GUI context.
+	 *
+	 * @param gui the GUI
+	 * @param scene the scene
+	 * @since 2.1.0
+	 */
+	public GuiContext(Gui gui, Scene scene) {
+		this.gui = gui;
+		this.scene = scene;
+	}
+
+	/**
+	 * Returns the GUI.
+	 *
+	 * @return the GUI
+	 * @since 2.1.0
+	 */
+	public Gui getGui() {
+		return gui;
+	}
+
+	/**
+	 * Returns the scene.
+	 *
+	 * @return the scene
+	 * @since 2.1.0
+	 */
+	public Scene getScene() {
+		return scene;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiRenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiRenderContext.java
@@ -1,0 +1,131 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Pixel;
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+
+import java.util.HashMap;
+
+/**
+ * The context for a GUI render cycle.
+ *
+ * @since 2.1.0
+ */
+public class GuiRenderContext extends RenderContext implements Cancelable {
+
+	private final HashMap<Integer, Pixel> renderOverrides = new HashMap<>();
+
+	private boolean canceled;
+
+	/**
+	 * Constructs a new render context.
+	 *
+	 * @param gui   the GUI
+	 * @param scene the scene
+	 * @since 2.1.0
+	 */
+	public GuiRenderContext(Gui gui, Scene scene) {
+		super(gui, scene);
+	}
+
+	/**
+	 * Sets a render override for a slot. This will override the pixel
+	 * that would be rendered at the specified slot.
+	 * Pass {@code null} to remove the override.
+	 *
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @param pixel the pixel to render
+	 * @since 2.1.0
+	 */
+	public void setRenderOverride(int slotX, int slotY, Pixel pixel) {
+		if (slotX < 0 || slotX >= 9 || slotY < 0 || slotY >= 6) {
+			throw new IllegalArgumentException("Slot coordinates out of bounds (" + slotX + ", " + slotY + ")");
+		}
+		final int slot = slotX + 9 * slotY;
+
+		if (pixel == null) {
+			renderOverrides.remove(slot);
+			return;
+		}
+		renderOverrides.put(slot, pixel);
+	}
+
+	/**
+	 * Removes a render override for a slot.
+	 * If the slot does not have an override, nothing happens.
+	 *
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public void removeOverride(int slotX, int slotY) {
+		if (slotX < 0 || slotX >= 9 || slotY < 0 || slotY >= 6) {
+			return;
+		}
+		final int slot = slotX + 9 * slotY;
+		renderOverrides.remove(slot);
+	}
+
+	/**
+	 * Clears all render overrides.
+	 *
+	 * @since 2.1.0
+	 */
+	public void clearRenderOverrides() {
+		renderOverrides.clear();
+	}
+
+	/**
+	 * Returns the render override for a slot.
+	 * If there is no override, {@code null} is returned.
+	 *
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @return the render override
+	 * @since 2.1.0
+	 */
+	public Pixel getRenderOverride(int slotX, int slotY) {
+		if (slotX < 0 || slotX >= 9 || slotY < 0 || slotY >= 6) {
+			return null;
+		}
+		final int slot = slotX + 9 * slotY;
+		return renderOverrides.get(slot);
+	}
+
+	/**
+	 * Returns a snapshot of the render overrides.
+	 * The key is represented as the slot index.
+	 *
+	 * @return the render overrides
+	 * @since 2.1.0
+	 */
+	public HashMap<Integer, Pixel> getRenderOverrides() {
+		return new HashMap<>(renderOverrides);
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return canceled;
+	}
+
+	@Override
+	public void setCanceled(boolean canceled) {
+		this.canceled = canceled;
+	}
+
+	/**
+	 * Copies this context for a different slot.
+	 *
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @return the new context
+	 * @since 2.1.0
+	 */
+	public PixelRenderContext copyForPixel(int slotX, int slotY) {
+		PixelRenderContext context = new PixelRenderContext(getGui(), getScene(), slotX, slotY);
+		context.renderStart = renderStart;
+		return context;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiRenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiRenderContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Pixel;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
@@ -1,6 +1,5 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
@@ -1,0 +1,58 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.ClickType;
+
+/**
+ * Represents a context of a slot click in a GUI.
+ *
+ * @since 2.1.0
+ */
+public class GuiSlotClickContext extends GuiClickContext {
+
+	private final int slotX;
+	private final int slotY;
+
+	/**
+	 * Constructs a new slot click context.
+	 *
+	 * @param gui the GUI
+	 * @param scene the scene
+	 * @param type the click type
+	 * @param hotBarButton the hot bar button
+	 * @param whoClicked the human entity that
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public GuiSlotClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY) {
+		super(gui, scene, type, hotBarButton, whoClicked);
+		this.slotX = slotX;
+		this.slotY = slotY;
+	}
+
+	/**
+	 * Returns the x coordinate of the slot.
+	 * This is relative to the top-left corner of the GUI.
+	 *
+	 * @return the x coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public int getSlotX() {
+		return slotX;
+	}
+
+	/**
+	 * Returns the y coordinate of the slot.
+	 * This is relative to the top-left corner of the GUI.
+	 *
+	 * @return the y coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public int getSlotY() {
+		return slotY;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/GuiSlotClickContext.java
@@ -1,5 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;
@@ -20,6 +21,7 @@ public class GuiSlotClickContext extends GuiClickContext {
 	 *
 	 * @param gui the GUI
 	 * @param scene the scene
+	 * @param area the area of the click
 	 * @param type the click type
 	 * @param hotBarButton the hot bar button
 	 * @param whoClicked the human entity that
@@ -27,8 +29,8 @@ public class GuiSlotClickContext extends GuiClickContext {
 	 * @param slotY the y coordinate of the slot
 	 * @since 2.1.0
 	 */
-	public GuiSlotClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY) {
-		super(gui, scene, type, hotBarButton, whoClicked);
+	public GuiSlotClickContext(Gui gui, Scene scene, GuiArea area, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY) {
+		super(gui, scene, area, type, hotBarButton, whoClicked);
 		this.slotX = slotX;
 		this.slotY = slotY;
 	}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -1,6 +1,5 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Node;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -100,7 +100,9 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 * @return the new context
 	 */
 	public NodeClickContext copyFor(Node target) {
-		return new NodeClickContext(getGui(), getScene(), getType(), getHotBarButton(), getWhoClicked(), getSlotX(), getSlotY(), getSource(), target);
+		NodeClickContext newContext = new NodeClickContext(getGui(), getScene(), getType(), getHotBarButton(), getWhoClicked(), getSlotX(), getSlotY(), getSource(), target);
+		newContext.consumed = consumed;
+		return newContext;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -1,197 +1,42 @@
-/*
- * Copyright 2024, SomeSourceCode - MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the “Software”), to deal in
- * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
- * Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.ClickType;
 
 /**
- * Represents the context of a node click.
- * It contains information about the type of click that was performed and the player that clicked.
+ * Represents the context of a node click in a GUI.
  *
- * @since 1.0.0
+ * @since 2.0.0
  */
-public class NodeClickContext {
-
-	private final Scene scene;
-
-	private final int slotX;
-	private final int slotY;
-
-	private final ClickType type;
-
-	private final HumanEntity whoClicked;
-
-	private final int hotBarButton;
+public class NodeClickContext extends GuiSlotClickContext implements Consumable {
 
 	private boolean consumed;
 
 	/**
-	 * Creates a new node click context.
+	 * Constructs a new node click context.
 	 *
-	 * @param scene the scene the click occurred in
-	 * @param x the x coordinate of the slot that was clicked
-	 * @param y the y coordinate of the slot that was clicked
-	 * @param type the type of click that was performed
-	 * @param whoClicked the human entity that clicked the node
-	 * @param hotBarButton the hot bar button that was clicked
-	 * @since 1.0.0
+	 * @param gui the GUI
+	 * @param scene the scene
+	 * @param type the click type
+	 * @param hotBarButton the hotbar button
+	 * @param whoClicked the player who clicked
+	 * @param slotX the slot X
+	 * @param slotY the slot Y
 	 */
-	public NodeClickContext(Scene scene, int x, int y, ClickType type, HumanEntity whoClicked, int hotBarButton) {
-		this.scene = scene;
-		this.slotX = x;
-		this.slotY = y;
-		this.type = type;
-		this.whoClicked = whoClicked;
-		this.hotBarButton = hotBarButton;
+	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY) {
+		super(gui, scene, type, hotBarButton, whoClicked, slotX, slotY);
 	}
 
-	/**
-	 * Returns the scene the click occurred in.
-	 *
-	 * @return the scene the click occurred in
-	 * @since 1.0.0
-	 */
-	public Scene getScene() {
-		return scene;
-	}
-
-	/**
-	 * Returns the x coordinate of the slot that was clicked.
-	 * This is the slot's x coordinate in the inventory, and not relative to the nodes bounds.
-	 *
-	 * @return the x coordinate of the slot that was clicked
-	 * @since 1.0.0
-	 */
-	public int getSlotX() {
-		return slotX;
-	}
-
-	/**
-	 * Returns the y coordinate of the slot that was clicked.
-	 * This is the slot's y coordinate in the inventory, and not relative to the nodes bounds.
-	 *
-	 * @return the y coordinate of the slot that was clicked
-	 * @since 1.0.0
-	 */
-	public int getSlotY() {
-		return slotY;
-	}
-
-	/**
-	 * Returns the type of click that was performed.
-	 *
-	 * @return the type of click that was performed
-	 * @since 1.0.0
-	 */
-	public ClickType getType() {
-		return type;
-	}
-
-	/**
-	 * Return true if the click was a left click; false otherwise.
-	 * This method is equivalent to calling {@code getType().isLeftClick()}.
-	 *
-	 * @return whether the click was a left click
-	 * @since 1.0.0
-	 */
-	public boolean isLeftClick() {
-		return type.isLeftClick();
-	}
-
-	/**
-	 * Return true if the click was a right click; false otherwise.
-	 * This method is equivalent to calling {@code getType().isRightClick()}.
-	 *
-	 * @return whether the click was a right click
-	 * @since 1.0.0
-	 */
-	public boolean isRightClick() {
-		return type.isRightClick();
-	}
-
-	/**
-	 * Return true if the click was a shift click; false otherwise.
-	 * This method is equivalent to calling {@code getType().isShiftClick()}.
-	 *
-	 * @return whether the click was a shift click
-	 * @since 1.0.0
-	 */
-	public boolean isShiftClick() {
-		return type.isShiftClick();
-	}
-
-	/**
-	 * Return true if the click was a hot bar click; false otherwise.
-	 *
-	 * @return whether the click was a hot bar click
-	 * @since 1.0.0
-	 */
-	public boolean isHotBarClick() {
-		return hotBarButton != -1;
-	}
-
-	/**
-	 * Returns the human entity that clicked the node.
-	 *
-	 * @return the human entity that clicked the node
-	 * @since 1.0.0
-	 */
-	public HumanEntity getWhoClicked() {
-		return whoClicked;
-	}
-
-	/**
-	 * Returns the hot bar button that was clicked.
-	 * If the click was not a hot bar click, this method returns -1.
-	 *
-	 * @return the hot bar button that was clicked
-	 * @since 1.0.0
-	 */
-	public int getHotBarButton() {
-		return hotBarButton;
-	}
-
-	/**
-	 * Returns true if the click has been consumed; false otherwise.
-	 *
-	 * @return whether the click has been consumed
-	 * @since 1.0.0
-	 */
+	@Override
 	public boolean isConsumed() {
 		return consumed;
 	}
 
-	/**
-	 * Consumes the click.
-	 * Once a click has been consumed, {@link #isConsumed()} will return {@code true}.
-	 *
-	 * @since 1.0.0
-	 */
+	@Override
 	public void consume() {
-		consumed = true;
+		this.consumed = true;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -14,6 +14,7 @@ import org.bukkit.event.inventory.ClickType;
 public class NodeClickContext extends GuiSlotClickContext implements Consumable {
 
 	private final Node source;
+	private final Node target;
 
 	private boolean consumed;
 
@@ -28,22 +29,58 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 * @param slotX the slot X
 	 * @param slotY the slot Y
 	 * @param source the source node
+	 * @param target the target node
 	 */
-	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY, Node source) {
+	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY, Node source, Node target) {
 		super(gui, scene, type, hotBarButton, whoClicked, slotX, slotY);
 		this.source = source;
+		this.target = target;
 	}
 
 	/**
 	 * Returns the source node of the click. The source
 	 * of the event never changes as it points to the
 	 * node that was clicked.
+	 * <p>
+	 * Given a button is clicked that is inside
+	 * a container and this code:
+	 * <pre><code>
+	 * container.setOnClick(context -> {
+	 *     context.getSource(); // Returns the button
+	 *     context.getTarget(); // whereas this returns the container
+     * })
+	 * </code></pre>
 	 *
 	 * @return the source node
+	 * @see #getTarget()
 	 * @since 2.1.0
 	 */
 	public Node getSource() {
 		return source;
+	}
+
+	/**
+	 * Returns the target node of the click. The target
+	 * of the event will point to the node that is currently
+	 * processing the event.
+	 * <p>
+	 * Given a button is clicked that is inside
+	 * a container and this code:
+	 * <pre><code>
+	 * container.setOnClick(context -> {
+	 *     context.getTarget(); // Returns the container
+	 *     context.getSource(); // whereas this returns the button
+	 * })
+	 * </code></pre>
+	 * This method is useful if there are multiple nodes
+	 * using the same event handler.
+	 *
+	 * @return the target node
+	 * @see #getSource()
+	 * @since 2.1.0
+	 */
+	public Node getTarget() {
+		return target;
 	}
 
 	@Override
@@ -54,6 +91,16 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	@Override
 	public void consume() {
 		this.consumed = true;
+	}
+
+	/**
+	 * Copies this context for the given target node.
+	 *
+	 * @param target the new target node
+	 * @return the new context
+	 */
+	public NodeClickContext copyFor(Node target) {
+		return new NodeClickContext(getGui(), getScene(), getType(), getHotBarButton(), getWhoClicked(), getSlotX(), getSlotY(), getSource(), target);
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -1,5 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.Node;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
@@ -23,6 +24,7 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 *
 	 * @param gui the GUI
 	 * @param scene the scene
+	 * @param area the area of the click
 	 * @param type the click type
 	 * @param hotBarButton the hotbar button
 	 * @param whoClicked the player who clicked
@@ -31,8 +33,8 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 * @param source the source node
 	 * @param target the target node
 	 */
-	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY, Node source, Node target) {
-		super(gui, scene, type, hotBarButton, whoClicked, slotX, slotY);
+	public NodeClickContext(Gui gui, Scene scene, GuiArea area, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY, Node source, Node target) {
+		super(gui, scene, area, type, hotBarButton, whoClicked, slotX, slotY);
 		this.source = source;
 		this.target = target;
 	}
@@ -100,7 +102,7 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 * @return the new context
 	 */
 	public NodeClickContext copyFor(Node target) {
-		NodeClickContext newContext = new NodeClickContext(getGui(), getScene(), getType(), getHotBarButton(), getWhoClicked(), getSlotX(), getSlotY(), getSource(), target);
+		NodeClickContext newContext = new NodeClickContext(getGui(), getScene(), getArea(), getType(), getHotBarButton(), getWhoClicked(), getSlotX(), getSlotY(), getSource(), target);
 		newContext.consumed = consumed;
 		return newContext;
 	}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -1,5 +1,6 @@
 package io.github.somesourcecode.someguiapi.scene.context;
 
+import io.github.somesourcecode.someguiapi.scene.Node;
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 import org.bukkit.entity.HumanEntity;
@@ -11,6 +12,8 @@ import org.bukkit.event.inventory.ClickType;
  * @since 2.0.0
  */
 public class NodeClickContext extends GuiSlotClickContext implements Consumable {
+
+	private final Node source;
 
 	private boolean consumed;
 
@@ -24,9 +27,23 @@ public class NodeClickContext extends GuiSlotClickContext implements Consumable 
 	 * @param whoClicked the player who clicked
 	 * @param slotX the slot X
 	 * @param slotY the slot Y
+	 * @param source the source node
 	 */
-	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY) {
+	public NodeClickContext(Gui gui, Scene scene, ClickType type, int hotBarButton, HumanEntity whoClicked, int slotX, int slotY, Node source) {
 		super(gui, scene, type, hotBarButton, whoClicked, slotX, slotY);
+		this.source = source;
+	}
+
+	/**
+	 * Returns the source node of the click. The source
+	 * of the event never changes as it points to the
+	 * node that was clicked.
+	 *
+	 * @return the source node
+	 * @since 2.1.0
+	 */
+	public Node getSource() {
+		return source;
 	}
 
 	@Override

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/NodeClickContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Node;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/PixelRenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/PixelRenderContext.java
@@ -1,0 +1,53 @@
+package io.github.somesourcecode.someguiapi.scene.context;
+
+import io.github.somesourcecode.someguiapi.scene.Scene;
+import io.github.somesourcecode.someguiapi.scene.gui.Gui;
+
+/**
+ * The context for a pixel render cycle.
+ *
+ * @since 2.1.0
+ */
+public class PixelRenderContext extends RenderContext {
+
+	private final int slotX;
+	private final int slotY;
+
+	/**
+	 * Constructs a new pixel render context.
+	 *
+	 * @param gui   the GUI
+	 * @param scene the scene
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public PixelRenderContext(Gui gui, Scene scene, int slotX, int slotY) {
+		super(gui, scene);
+		this.slotX = slotX;
+		this.slotY = slotY;
+	}
+
+	/**
+	 * Returns the x coordinate of the slot.
+	 * This is relative to the top-left corner of the GUI.
+	 *
+	 * @return the x coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public int getSlotX() {
+		return slotX;
+	}
+
+	/**
+	 * Returns the y coordinate of the slot.
+	 * This is relative to the top-left corner of the GUI.
+	 *
+	 * @return the y coordinate of the slot
+	 * @since 2.1.0
+	 */
+	public int getSlotY() {
+		return slotY;
+	}
+
+}

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/PixelRenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/PixelRenderContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
@@ -1,71 +1,24 @@
-/*
- * Copyright 2024, SomeSourceCode - MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the “Software”), to deal in
- * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
- * Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;
 import io.github.somesourcecode.someguiapi.scene.gui.Gui;
 
 /**
- * The context in which a pixel is rendered.
+ * The context for a GUI render cycle.
  *
  * @since 2.0.0
  */
-public class RenderContext {
-
-	private final Gui gui;
-	private final Scene scene;
+public class RenderContext extends GuiContext {
 
 	/**
 	 * Constructs a new render context.
 	 *
-	 * @param gui the gui
+	 * @param gui the GUI
 	 * @param scene the scene
-	 * @since 2.0.0
+	 * @since 2.1.0
 	 */
 	public RenderContext(Gui gui, Scene scene) {
-		this.gui = gui;
-		this.scene = scene;
-	}
-
-	/**
-	 * Returns the gui in which the pixel is rendered.
-	 *
-	 * @return the gui
-	 * @since 2.0.0
-	 */
-	public Gui getGui() {
-		return gui;
-	}
-
-	/**
-	 * Returns the scene in which the pixel is rendered.
-	 *
-	 * @return the scene
-	 * @since 2.0.0
-	 */
-	public Scene getScene() {
-		return scene;
+		super(gui, scene);
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
@@ -10,6 +10,8 @@ import io.github.somesourcecode.someguiapi.scene.gui.Gui;
  */
 public class RenderContext extends GuiContext {
 
+	protected long renderStart;
+
 	/**
 	 * Constructs a new render context.
 	 *
@@ -19,6 +21,28 @@ public class RenderContext extends GuiContext {
 	 */
 	public RenderContext(Gui gui, Scene scene) {
 		super(gui, scene);
+		renderStart = System.currentTimeMillis();
+	}
+
+	/**
+	 * Returns the time when the render cycle started.
+	 *
+	 * @return the time when the render cycle started
+	 * @since 2.1.0
+	 */
+	public long getRenderStart() {
+		return renderStart;
+	}
+
+	/**
+	 * Returns the time it took to render the GUI
+	 * since the render cycle started.
+	 *
+	 * @return the time it took to render the GUI
+	 * @since 2.1.0
+	 */
+	public long getRenderTime() {
+		return System.currentTimeMillis() - renderStart;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/context/RenderContext.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.scene.context;
 
 import io.github.somesourcecode.someguiapi.scene.Scene;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -23,10 +23,9 @@
 
 package io.github.somesourcecode.someguiapi.scene.gui;
 
-import io.github.somesourcecode.someguiapi.collections.GuiArea;
+import io.github.somesourcecode.someguiapi.scene.context.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.*;
 import io.github.somesourcecode.someguiapi.scene.context.GuiRenderContext;
-import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -29,6 +29,7 @@ import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -148,12 +149,18 @@ public class ChestGui extends Gui implements InventoryHolder {
 	 * Fires the onClick event for the node at the given coordinates.
 	 * The listeners a called for the clicked node and all of its parents, respectively.
 	 *
-	 * @param context the click context
-	 * @see Scene#handleClick(NodeClickContext)
+	 * @param clickType the click type
+	 * @param hotbarButton the hot bar button
+	 * @param whoClicked the human entity that clicked
+	 * @param slotX the x coordinate of the slot
+	 * @param slotY the y coordinate of the slot
 	 * @since 2.1.0
 	 */
-	public void handleClick(NodeClickContext context) {
-		scene.handleClick(context);
+	public void handleClick(ClickType clickType, int hotbarButton, HumanEntity whoClicked, int slotX, int slotY) {
+		if (scene == null) {
+			return;
+		}
+		scene.handleClick(clickType, hotbarButton, whoClicked, slotX, slotY);
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -23,6 +23,7 @@
 
 package io.github.somesourcecode.someguiapi.scene.gui;
 
+import io.github.somesourcecode.someguiapi.collections.GuiArea;
 import io.github.somesourcecode.someguiapi.scene.*;
 import io.github.somesourcecode.someguiapi.scene.context.GuiRenderContext;
 import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
@@ -166,6 +167,7 @@ public class ChestGui extends Gui implements InventoryHolder {
 	 * Fires the onClick event for the node at the given coordinates.
 	 * The listeners a called for the clicked node and all of its parents, respectively.
 	 *
+	 * @param area the area of the click
 	 * @param clickType the click type
 	 * @param hotbarButton the hot bar button
 	 * @param whoClicked the human entity that clicked
@@ -173,11 +175,11 @@ public class ChestGui extends Gui implements InventoryHolder {
 	 * @param slotY the y coordinate of the slot
 	 * @since 2.1.0
 	 */
-	public void handleClick(ClickType clickType, int hotbarButton, HumanEntity whoClicked, int slotX, int slotY) {
+	public void handleClick(GuiArea area, ClickType clickType, int hotbarButton, HumanEntity whoClicked, int slotX, int slotY) {
 		if (scene == null) {
 			return;
 		}
-		scene.handleClick(clickType, hotbarButton, whoClicked, slotX, slotY);
+		scene.handleClick(area, clickType, hotbarButton, whoClicked, slotX, slotY);
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -24,6 +24,7 @@
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.*;
+import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
@@ -141,6 +142,18 @@ public class ChestGui extends Gui implements InventoryHolder {
 
 		clearDirtyFlag(DirtyFlag.GUI_CONTENT);
 		rendering = false;
+	}
+
+	/**
+	 * Fires the onClick event for the node at the given coordinates.
+	 * The listeners a called for the clicked node and all of its parents, respectively.
+	 *
+	 * @param context the click context
+	 * @see Scene#handleClick(NodeClickContext)
+	 * @since 2.1.0
+	 */
+	public void handleClick(NodeClickContext context) {
+		scene.handleClick(context);
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -24,7 +24,6 @@
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.*;
-import io.github.somesourcecode.someguiapi.scene.context.NodeClickContext;
 import io.github.somesourcecode.someguiapi.scene.context.RenderContext;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -66,6 +66,7 @@ public abstract class Gui {
 
 	protected final EnumSet<DirtyFlag> dirtyFlags = EnumSet.noneOf(DirtyFlag.class);
 
+	private Consumer<GuiClickContext> onClick;
 	private Consumer<GuiSlotClickContext> onGuiClick;
 	private Consumer<GuiClickContext> onOutsideClick;
 	private Consumer<GuiCloseContext> onClose;
@@ -142,6 +143,37 @@ public abstract class Gui {
 	 */
 	public final boolean isDirty(DirtyFlag flag) {
 		return dirtyFlags.contains(flag);
+	}
+
+	/**
+	 * Returns the consumer that is called when a click occurs.
+	 *
+	 * @return the consumer that is called when a click occurs
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiClickContext> getOnClick() {
+		return onClick;
+	}
+
+	/**
+	 * Sets the consumer that is called when a click occurs.
+	 *
+	 * @param onClick the consumer that is called when a click occurs
+	 * @since 2.1.0
+	 */
+	public void setOnClick(Consumer<GuiClickContext> onClick) {
+		this.onClick = onClick;
+	}
+
+	/**
+	 * Fires the consumer, set by {@link #setOnClick(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnClick(GuiClickContext context) {
+		fireCallback(onClick, context, "onClick");
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -24,10 +24,7 @@
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.DirtyFlag;
-import io.github.somesourcecode.someguiapi.scene.context.Context;
-import io.github.somesourcecode.someguiapi.scene.context.GuiClickContext;
-import io.github.somesourcecode.someguiapi.scene.context.GuiCloseContext;
-import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.*;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
@@ -72,6 +69,8 @@ public abstract class Gui {
 	private Consumer<GuiSlotClickContext> onGuiClick;
 	private Consumer<GuiClickContext> onOutsideClick;
 	private Consumer<GuiCloseContext> onClose;
+
+	private Consumer<GuiRenderContext> onRender;
 
 	protected Inventory inventory;
 
@@ -236,6 +235,37 @@ public abstract class Gui {
 	 */
 	public void fireOnClose(GuiCloseContext context) {
 		fireCallback(onClose, context, "onClose");
+	}
+
+	/**
+	 * Returns the consumer that is called when the GUI is rendered.
+	 *
+	 * @return the consumer that is called when the GUI is rendered
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiRenderContext> getOnRender() {
+		return onRender;
+	}
+
+	/**
+	 * Sets the consumer that is called when the GUI is rendered.
+	 *
+	 * @param onRender the consumer that is called when the GUI is rendered
+	 * @since 2.1.0
+	 */
+	public void setOnRender(Consumer<GuiRenderContext> onRender) {
+		this.onRender = onRender;
+	}
+
+	/**
+	 * Fires the consumer, set by {@link #setOnRender(Consumer)}, with the specified context.
+	 * Catches and logs any exceptions that might be thrown by the consumer.
+	 *
+	 * @param context the context
+	 * @since 2.1.0
+	 */
+	public void fireOnRender(GuiRenderContext context) {
+		fireCallback(onRender, context, "onRender");
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -24,6 +24,9 @@
 package io.github.somesourcecode.someguiapi.scene.gui;
 
 import io.github.somesourcecode.someguiapi.scene.DirtyFlag;
+import io.github.somesourcecode.someguiapi.scene.context.GuiClickContext;
+import io.github.somesourcecode.someguiapi.scene.context.GuiCloseContext;
+import io.github.somesourcecode.someguiapi.scene.context.GuiSlotClickContext;
 import io.github.somesourcecode.someguiapi.scene.data.ContextDataHolder;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
@@ -31,6 +34,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * The base class for GUIs that can be shown to players.
@@ -61,6 +65,10 @@ public abstract class Gui {
 	protected final ContextDataHolder dataHolder = new ContextDataHolder();
 
 	protected final EnumSet<DirtyFlag> dirtyFlags = EnumSet.noneOf(DirtyFlag.class);
+
+	private Consumer<GuiSlotClickContext> onGuiClick;
+	private Consumer<GuiClickContext> onOutsideClick;
+	private Consumer<GuiCloseContext> onClose;
 
 	protected Inventory inventory;
 
@@ -135,6 +143,66 @@ public abstract class Gui {
 	}
 
 	/**
+	 * Returns the consumer that is called when the GUI is clicked.
+	 *
+	 * @return the consumer that is called when the GUI is clicked
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiSlotClickContext> getOnGuiClick() {
+		return onGuiClick;
+	}
+
+	/**
+	 * Sets the consumer that is called when the GUI is clicked.
+	 *
+	 * @param onGuiClick the consumer that is called when the GUI is clicked
+	 * @since 2.1.0
+	 */
+	public void setOnGuiClick(Consumer<GuiSlotClickContext> onGuiClick) {
+		this.onGuiClick = onGuiClick;
+	}
+
+	/**
+	 * Returns the consumer that is called when the GUI is clicked outside the GUI.
+	 *
+	 * @return the consumer that is called when the GUI is clicked outside the GUI
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiClickContext> getOnOutsideClick() {
+		return onOutsideClick;
+	}
+
+	/**
+	 * Sets the consumer that is called when the GUI is clicked outside the GUI.
+	 *
+	 * @param onOutsideClick the consumer that is called when the GUI is clicked outside the GUI
+	 * @since 2.1.0
+	 */
+	public void setOnOutsideClick(Consumer<GuiClickContext> onOutsideClick) {
+		this.onOutsideClick = onOutsideClick;
+	}
+
+	/**
+	 * Returns the consumer that is called when the GUI is closed.
+	 *
+	 * @return the consumer that is called when the GUI is closed
+	 * @since 2.1.0
+	 */
+	public Consumer<GuiCloseContext> getOnClose() {
+		return onClose;
+	}
+
+	/**
+	 * Sets the consumer that is called when the GUI is closed.
+	 *
+	 * @param onClose the consumer that is called when the GUI is closed
+	 * @since 2.1.0
+	 */
+	public void setOnClose(Consumer<GuiCloseContext> onClose) {
+		this.onClose = onClose;
+	}
+
+	/**
 	 * Shows this GUI to the specified human entity.
 	 *
 	 * @param humanEntity the human entity
@@ -150,12 +218,27 @@ public abstract class Gui {
 	 */
 	public abstract List<HumanEntity> getViewers();
 
+	private boolean updating = false;
+
+	/**
+	 * Returns whether this GUI is currently updating.
+	 *
+	 * @return whether this GUI is updating
+	 */
+	public boolean isUpdating() {
+		return updating;
+	}
+
 	/**
 	 * Updates the GUI for all viewers.
 	 *
 	 * @since 1.0.0
 	 */
 	public void update() {
+		if (updating) {
+			return;
+		}
+		updating = true;
 		for (HumanEntity viewer : getViewers()) {
 			ItemStack cursor = viewer.getItemOnCursor();
 			viewer.setItemOnCursor(null);
@@ -164,6 +247,7 @@ public abstract class Gui {
 
 			viewer.setItemOnCursor(cursor);
 		}
+		updating = false;
 	}
 
 }


### PR DESCRIPTION
### Description

This pull request adds several new events as requested in #18, such as

- `Gui#onClick` - when a click occurs
- `Gui#onGuiClick` - for clicks inside the GUI
- `Gui#onOutsideClick` - for clicks outside the GUI
- `Gui#onClose` - when the GUI is closed
- `Gui#onRender` - fired every render cycle

Existing events are further enhanced, so that

- `RenderContext` is split into `GuiRenderContext` and `PixelRenderContext`
- `NodeClickContext` contains a `target` and a `source` node
- `RenderContext` contains information about render time
- `PixelRenderContext` holds the slot