### PR TITLE
Implement cycle detection

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/Change.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/Change.java
@@ -42,8 +42,6 @@ public class Change<E> {
 	private final boolean wasAdded;
 	private final boolean wasRemoved;
 
-	private boolean denied = false;
-
 	/**
 	 * Constructs a new change with the specified added and removed sublists.
 	 *
@@ -99,26 +97,6 @@ public class Change<E> {
 	 */
 	public boolean wasRemoved() {
 		return wasRemoved;
-	}
-
-	/**
-	 * Denies the change. If a change is denied,
-	 * it will not be applied.
-	 *
-	 * @since 2.1.0
-	 */
-	public void deny() {
-		denied = true;
-	}
-
-	/**
-	 * Returns whether the change was denied.
-	 *
-	 * @return whether the change was denied
-	 * @since 2.1.0
-	 */
-	public boolean isDenied() {
-		return denied;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/Change.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/Change.java
@@ -42,6 +42,8 @@ public class Change<E> {
 	private final boolean wasAdded;
 	private final boolean wasRemoved;
 
+	private boolean denied = false;
+
 	/**
 	 * Constructs a new change with the specified added and removed sublists.
 	 *
@@ -97,6 +99,26 @@ public class Change<E> {
 	 */
 	public boolean wasRemoved() {
 		return wasRemoved;
+	}
+
+	/**
+	 * Denies the change. If a change is denied,
+	 * it will not be applied.
+	 *
+	 * @since 2.1.0
+	 */
+	public void deny() {
+		denied = true;
+	}
+
+	/**
+	 * Returns whether the change was denied.
+	 *
+	 * @return whether the change was denied
+	 * @since 2.1.0
+	 */
+	public boolean isDenied() {
+		return denied;
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/ObservableList.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/ObservableList.java
@@ -70,4 +70,13 @@ public interface ObservableList<E> extends List<E> {
 	 */
 	boolean removeAll(E... elements);
 
+	/**
+	 * A convenience method to retain only the varargs elements in the list.
+	 *
+	 * @param elements the elements to retain
+	 * @return true if the list was changed as a result of this call
+	 * @since 2.1.0
+	 */
+	boolean retainAll(E... elements);
+
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/ObservableListBase.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/ObservableListBase.java
@@ -94,52 +94,55 @@ public class ObservableListBase<E> implements ObservableList<E> {
 	@Override
 	public boolean add(E e) {
 		baseList.add(e);
-		Change<E> change = new Change<>(Collections.singletonList(e), null);
-		fireChange(change);
+		fireChange(new Change<>(Collections.singletonList(e), null));
 		return true;
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean remove(Object o) {
 		boolean result = baseList.remove(o);
 		if (result) {
-			Change<E> change = new Change<>(null, Collections.singletonList((E) o));
-			fireChange(change);
+			fireChange(new Change<>(null, Collections.singletonList((E) o)));
 		}
 		return result;
 	}
 
 	@Override
-	public boolean containsAll(Collection<?> c) {
+	public boolean containsAll(@NotNull Collection<?> c) {
 		return new HashSet<>(baseList).containsAll(c);
+	}
+
+	@Override
+	public boolean addAll(E... elements) {
+		return addAll(Arrays.asList(elements));
 	}
 
 	@Override
 	public boolean addAll(@NotNull Collection<? extends E> c) {
 		boolean result = baseList.addAll(c);
-
 		if (result) {
-			Change<E> change = new Change<>(new ArrayList<>(c), null);
-			fireChange(change);
+			fireChange(new Change<>(new ArrayList<>(c), null));
 		}
-
 		return result;
 	}
 
 	@Override
 	public boolean addAll(int index, @NotNull Collection<? extends E> c) {
 		boolean result = baseList.addAll(index, c);
-
 		if (result) {
-			Change<E> change = new Change<>(new ArrayList<>(c), null);
-			fireChange(change);
+			fireChange(new Change<>(new ArrayList<>(c), null));
 		}
-
 		return result;
 	}
 
 	@Override
-	public boolean removeAll(Collection<?> c) {
+	public boolean removeAll(E... elements) {
+		return removeAll(Arrays.asList(elements));
+	}
+
+	@Override
+	public boolean removeAll(@NotNull Collection<?> c) {
 		List<E> originalList = new ArrayList<>(baseList);
 		boolean result = baseList.removeAll(c);
 
@@ -153,8 +156,12 @@ public class ObservableListBase<E> implements ObservableList<E> {
 			Change<E> change = new Change<>(null, removedElements);
 			fireChange(change);
 		}
-
 		return result;
+	}
+
+	@Override
+	public boolean retainAll(E... elements) {
+		return retainAll(Arrays.asList(elements));
 	}
 
 	@Override
@@ -172,16 +179,13 @@ public class ObservableListBase<E> implements ObservableList<E> {
 			Change<E> change = new Change<>(null, removedElements);
 			fireChange(change);
 		}
-
 		return result;
 	}
 
 	@Override
 	public void clear() {
-		List<E> removedElements = new ArrayList<>(baseList);
 		baseList.clear();
-		Change<E> change = new Change<>(null, removedElements);
-		fireChange(change);
+		fireChange(new Change<>(null, new ArrayList<>(baseList)));
 	}
 
 	@Override
@@ -191,27 +195,24 @@ public class ObservableListBase<E> implements ObservableList<E> {
 
 	@Override
 	public E set(int index, E element) {
-		E baseElement = baseList.set(index, element);
-		if (baseElement != element) {
-			Change<E> change = new Change<>(Collections.singletonList(element), Collections.singletonList(baseElement));
-			fireChange(change);
+		E previousElement = baseList.set(index, element);
+		if (previousElement != element) {
+			fireChange(new Change<>(Collections.singletonList(element), Collections.singletonList(previousElement)));
 		}
-		return baseElement;
+		return previousElement;
 	}
 
 	@Override
 	public void add(int index, E element) {
 		baseList.add(index, element);
-		Change<E> change = new Change<>(Collections.singletonList(element), null);
-		fireChange(change);
+		fireChange(new Change<>(Collections.singletonList(element), null));
 	}
 
 	@Override
 	public E remove(int index) {
-		E removedElement = baseList.remove(index);
-		Change<E> change = new Change<>(null, Collections.singletonList(removedElement));
-		fireChange(change);
-		return removedElement;
+		E result = baseList.remove(index);
+		fireChange(new Change<>(null, Collections.singletonList(baseList.get(index))));
+		return result;
 	}
 
 	@Override
@@ -237,18 +238,6 @@ public class ObservableListBase<E> implements ObservableList<E> {
 	@Override
 	public @NotNull List<E> subList(int fromIndex, int toIndex) {
 		return baseList.subList(fromIndex, toIndex);
-	}
-
-	@Override
-	public boolean addAll(E... elements) {
-		Change<E> change = new Change<>(Arrays.asList(elements), null);
-		fireChange(change);
-		return Collections.addAll(baseList, elements);
-	}
-
-	@Override
-	public boolean removeAll(E... elements) {
-		return removeAll(Arrays.asList(elements));
 	}
 
 	private void fireChange(Change<E> change) {

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/VetoableListDecorator.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/VetoableListDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2024, SomeSourceCode - MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.somesourcecode.someguiapi.collections;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/github/somesourcecode/someguiapi/collections/VetoableListDecorator.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/collections/VetoableListDecorator.java
@@ -1,0 +1,221 @@
+package io.github.somesourcecode.someguiapi.collections;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * A decorator for an {@link ObservableList} that allows to veto changes to the list.
+ * <p>
+ * This class works as a wrapper around any {@link ObservableList} and fires
+ * change events whenever elements are added or removed.
+ *
+ * @param <E> the type of elements in the list
+ * @since 2.1.0
+ */
+public abstract class VetoableListDecorator<E> implements ObservableList<E> {
+
+	private final ObservableList<E> baseList;
+
+	public VetoableListDecorator(ObservableList<E> baseList) {
+		this.baseList = baseList;
+	}
+
+	@Override
+	public void addListener(ListChangeListener<? super E> listener) {
+		baseList.addListener(listener);
+	}
+
+	@Override
+	public void removeListener(ListChangeListener<? super E> listener) {
+		baseList.removeListener(listener);
+	}
+
+	/**
+	 * Called whenever a change is proposed to the list.
+	 * <p>
+	 * {@code toBeAdded} contains the elements that are proposed to be added to the list.
+	 * {@code toBeRemoved} contains the indices of the elements that are proposed to be removed from the list.
+	 * They are listed in pairs of two, where the first index is the start index (inclusive) and the
+	 * second index is the end index (exclusive).
+	 *
+	 * @param toBeAdded the elements to be added
+	 * @param toBeRemoved the indices of the elements to be removed
+	 * @throws IllegalStateException if the change is vetoed
+	 * @since 2.1.0
+	 */
+	protected abstract void onProposedChange(List<E> toBeAdded, int... toBeRemoved);
+
+	private void removeFromList(Collection<?> collection, boolean complement) {
+		int[] toBeRemoved = new int[0];
+		int pointer = 0;
+		for (int i = 0; i < size(); i++) {
+			final E element = get(i);
+			if ((collection.contains(element) ^ complement)) {
+				if (pointer % 2 == 0) {
+					if (toBeRemoved.length == pointer) {
+						toBeRemoved = Arrays.copyOf(toBeRemoved, toBeRemoved.length + 2);
+					}
+					toBeRemoved[pointer] = i;
+					pointer++;
+				}
+			} else {
+				if (pointer % 2 == 1) {
+					toBeRemoved[pointer] = i;
+					pointer++;
+				}
+			}
+		}
+		if (pointer % 2 == 1) {
+			toBeRemoved[pointer] = size();
+		}
+		onProposedChange(Collections.emptyList(), toBeRemoved);
+	}
+
+	@Override
+	public int size() {
+		return baseList.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return baseList.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return baseList.contains(o);
+	}
+
+	@NotNull
+	@Override
+	public Iterator<E> iterator() {
+		return baseList.iterator();
+	}
+
+	@NotNull
+	@Override
+	public Object @NotNull [] toArray() {
+		return baseList.toArray();
+	}
+
+	@NotNull
+	@Override
+	public <T> T @NotNull [] toArray(@NotNull T[] a) {
+		return baseList.toArray(a);
+	}
+
+	@Override
+	public boolean add(E e) {
+		onProposedChange(Collections.singletonList(e));
+		return baseList.add(e);
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		onProposedChange(Collections.emptyList(), indexOf(o));
+		return baseList.remove(o);
+	}
+
+	@Override
+	public boolean containsAll(@NotNull Collection<?> c) {
+		return new HashSet<>(baseList).containsAll(c);
+	}
+
+	@Override
+	public boolean addAll(E... elements) {
+		return addAll(Arrays.asList(elements));
+	}
+
+	@Override
+	public boolean addAll(@NotNull Collection<? extends E> c) {
+		onProposedChange(List.copyOf(c));
+		return baseList.addAll(c);
+	}
+
+	@Override
+	public boolean addAll(int index, @NotNull Collection<? extends E> c) {
+		onProposedChange(List.copyOf(c));
+		return baseList.addAll(index, c);
+	}
+
+	@Override
+	public boolean removeAll(E... elements) {
+		return removeAll(Arrays.asList(elements));
+	}
+
+	@Override
+	public boolean removeAll(@NotNull Collection<?> c) {
+		removeFromList(c, false);
+		return baseList.removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll(E... elements) {
+		return retainAll(Arrays.asList(elements));
+	}
+
+	@Override
+	public boolean retainAll(@NotNull Collection<?> c) {
+		removeFromList(c, true);
+		return baseList.retainAll(c);
+	}
+
+	@Override
+	public void clear() {
+		onProposedChange(Collections.emptyList(), 0, size());
+		baseList.clear();
+	}
+
+	@Override
+	public E get(int index) {
+		return baseList.get(index);
+	}
+
+	@Override
+	public E set(int index, E element) {
+		onProposedChange(Collections.singletonList(element), index, index + 1);
+		return baseList.set(index, element);
+	}
+
+	@Override
+	public void add(int index, E element) {
+		onProposedChange(Collections.singletonList(element));
+		baseList.add(index, element);
+	}
+
+	@Override
+	public E remove(int index) {
+		onProposedChange(Collections.emptyList(), index, index + 1);
+		return baseList.remove(index);
+	}
+
+	@Override
+	public int indexOf(Object o) {
+		return baseList.indexOf(o);
+	}
+
+	@Override
+	public int lastIndexOf(Object o) {
+		return baseList.lastIndexOf(o);
+	}
+
+	@NotNull
+	@Override
+	public ListIterator<E> listIterator() {
+		return baseList.listIterator();
+	}
+
+	@NotNull
+	@Override
+	public ListIterator<E> listIterator(int index) {
+		return baseList.listIterator(index);
+	}
+
+	@NotNull
+	@Override
+	public List<E> subList(int fromIndex, int toIndex) {
+		return baseList.subList(fromIndex, toIndex);
+	}
+
+}


### PR DESCRIPTION
### Description

Adds cycle detection as requested in #21.
This is achieved through a new `ObservableList` implementation called `VetoableListDecorator`, which allows `Parent`s to veto changes that would create a cycle in the node hierarchy. Additionally, `Parent` checks for invalid nodes, such as duplicates or `null` values.