### PR TITLE
Fix handling of null titles

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -297,6 +297,16 @@ public class ChestGui extends Gui implements InventoryHolder {
 	}
 
 	/**
+	 * Resets the title of this GUI. This has the same
+	 * effect as setting the title to null.
+	 *
+	 * @since 2.1.0
+	 */
+	public void resetTitle() {
+		setTitle((Component) null);
+	}
+
+	/**
 	 * Returns the number of rows of this GUI.
 	 *
 	 * @return the number of rows

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -67,7 +67,7 @@ public class ChestGui extends Gui implements InventoryHolder {
 		this.title = title;
 		this.rows = rows;
 
-		this.inventory = Bukkit.createInventory(this, rows * 9, title);
+		this.inventory = createInventory();
 		setDirtyFlag(DirtyFlag.GUI_CONTENT);
 	}
 
@@ -83,6 +83,12 @@ public class ChestGui extends Gui implements InventoryHolder {
 	}
 
 	@Override
+	public  Inventory createInventory() {
+		return title == null ? Bukkit.createInventory(this, rows * 9)
+				: Bukkit.createInventory(this, rows * 9, title);
+	}
+
+	@Override
 	public void show(HumanEntity humanEntity) {
 		if (getViewers().contains(humanEntity) && !isDirty()) {
 			return;
@@ -92,7 +98,7 @@ public class ChestGui extends Gui implements InventoryHolder {
 		ItemStack[] contents = Arrays.copyOf(inventory.getContents(), rows * 9);
 
 		if (isDirty(DirtyFlag.GUI_TITLE) || isDirty(DirtyFlag.GUI_ROWS)) {
-			inventory = Bukkit.createInventory(this, rows * 9, title);
+			inventory = createInventory();
 		}
 
 		if (!isDirty(DirtyFlag.GUI_CONTENT) && rows <= oldRows) {

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/ChestGui.java
@@ -79,7 +79,7 @@ public class ChestGui extends Gui implements InventoryHolder {
 	 * @since 2.1.0
 	 */
 	public ChestGui(String title, int rows) {
-		this(Component.text(title), rows);
+		this(title == null ? null : Component.text(title), rows);
 	}
 
 	@Override
@@ -287,7 +287,7 @@ public class ChestGui extends Gui implements InventoryHolder {
 	 * @since 2.1.0
 	 */
 	public void setTitle(String title) {
-		setTitle(Component.text(title));
+		setTitle(title == null ? null : Component.text(title));
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -301,6 +301,14 @@ public abstract class Gui {
 	}
 
 	/**
+	 * Creates the inventory for this GUI.
+	 *
+	 * @return the inventory
+	 * @since 2.1.0
+	 */
+	public abstract Inventory createInventory();
+
+	/**
 	 * Shows this GUI to the specified human entity.
 	 *
 	 * @param humanEntity the human entity


### PR DESCRIPTION
### Description

Fixes following exceptions:

- `NullPointerException` - occurs when `null` is passed as a `String` title as described in #25
- `IllegalArgumentException` - occurs when `null` is passed to `Bukkit#createInventory`

Additionally, a new method `ChestGui#resetTitle` has been introduced to reset the title.