### PR TITLE
Implement parent guis

### DIFF
--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -182,7 +182,14 @@ public abstract class Gui {
 		if (parent == this) {
 			throw new IllegalArgumentException("A GUI cannot be its own parent");
 		}
+		if (createsParentCycle(parent)) {
+			Bukkit.getLogger().log(Level.WARNING, "Parent cycle detected when setting parent of GUI " + this + " to " + parent);
+		}
 		this.parent = parent;
+	}
+
+	private boolean createsParentCycle(Gui parent) {
+		return parent == this || (parent != null && createsParentCycle(parent.getParent()));
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -182,14 +182,14 @@ public abstract class Gui {
 		if (parent == this) {
 			throw new IllegalArgumentException("A GUI cannot be its own parent");
 		}
-		if (createsParentCycle(parent)) {
-			Bukkit.getLogger().log(Level.WARNING, "Parent cycle detected when setting parent of GUI " + this + " to " + parent);
+		if (wouldCreateParentCycle(parent)) {
+			throw new IllegalArgumentException("Parent cycle detected when setting parent of GUI " + this + " to " + parent);
 		}
 		this.parent = parent;
 	}
 
-	private boolean createsParentCycle(Gui parent) {
-		return parent == this || (parent != null && createsParentCycle(parent.getParent()));
+	private boolean wouldCreateParentCycle(Gui parent) {
+		return parent == this || (parent != null && wouldCreateParentCycle(parent.getParent()));
 	}
 
 	/**

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -69,6 +69,8 @@ public abstract class Gui {
 
 	protected final EnumSet<DirtyFlag> dirtyFlags = EnumSet.noneOf(DirtyFlag.class);
 
+	private Gui parent;
+
 	private Consumer<? super GuiClickContext> onClick;
 	private Consumer<? super GuiSlotClickContext> onGuiClick;
 	private Consumer<? super GuiClickContext> onOutsideClick;
@@ -158,6 +160,74 @@ public abstract class Gui {
 	 */
 	public final boolean isDirty(DirtyFlag flag) {
 		return dirtyFlags.contains(flag);
+	}
+
+	/**
+	 * Returns the parent GUI of this GUI.
+	 *
+	 * @return the parent GUI
+	 * @since 2.0.1
+	 */
+	public Gui getParent() {
+		return parent;
+	}
+
+	/**
+	 * Sets the parent GUI of this GUI.
+	 *
+	 * @param parent the parent GUI
+	 * @since 2.0.1
+	 */
+	public void setParent(Gui parent) {
+		if (parent == this) {
+			throw new IllegalArgumentException("A GUI cannot be its own parent");
+		}
+		this.parent = parent;
+	}
+
+	/**
+	 * Navigates to the parent GUI for the specified viewer.
+	 * If there is no Parent GUI, this method does nothing.
+	 *
+	 * @param viewer the viewer
+	 * @since 2.0.1
+	 */
+	public void navigateToParent(HumanEntity viewer) {
+		if (parent == null || viewer == null) {
+			return;
+		}
+		parent.show(viewer);
+	}
+
+	/**
+	 * Navigates to the parent GUI for the specified viewer
+	 * or closes the GUI if there is no parent.
+	 *
+	 * @param viewer the viewer
+	 * @since 2.0.1
+	 */
+	public void navigateToParentOrClose(HumanEntity viewer) {
+		if (parent == null || viewer == null) {
+			close(viewer);
+			return;
+		}
+		parent.show(viewer);
+	}
+
+	/**
+	 * Navigates to the specified GUI for the specified viewer
+	 * and sets this GUI as the parent of the specified GUI.
+	 *
+	 * @param gui the GUI to navigate to
+	 * @param viewer the viewer
+	 * @since 2.0.1
+	 */
+	public void navigateTo(Gui gui, HumanEntity viewer) {
+		if (gui == null || gui == this || viewer == null || !getViewers().contains(viewer)) {
+			return;
+		}
+		gui.setParent(this);
+		gui.show(viewer);
 	}
 
 	/**
@@ -433,6 +503,24 @@ public abstract class Gui {
 			}
 			Bukkit.getLogger().log(Level.SEVERE, errorMessage, e);
 		}
+	}
+
+	public static Gui getGui(HumanEntity humanEntity) {
+		if (humanEntity == null || !(humanEntity.getOpenInventory().getTopInventory().getHolder() instanceof Gui gui)) {
+			return null;
+		}
+		return gui;
+	}
+
+	public static boolean hasOpenGui(HumanEntity humanEntity) {
+		return getGui(humanEntity) != null;
+	}
+
+	public static void closeGui(HumanEntity humanEntity) {
+		if (!hasOpenGui(humanEntity)) {
+			return;
+		}
+		getGui(humanEntity).close(humanEntity);
 	}
 
 }

--- a/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
+++ b/src/main/java/io/github/somesourcecode/someguiapi/scene/gui/Gui.java
@@ -166,7 +166,7 @@ public abstract class Gui {
 	 * Returns the parent GUI of this GUI.
 	 *
 	 * @return the parent GUI
-	 * @since 2.0.1
+	 * @since 2.1.0
 	 */
 	public Gui getParent() {
 		return parent;
@@ -176,7 +176,7 @@ public abstract class Gui {
 	 * Sets the parent GUI of this GUI.
 	 *
 	 * @param parent the parent GUI
-	 * @since 2.0.1
+	 * @since 2.1.0
 	 */
 	public void setParent(Gui parent) {
 		if (parent == this) {
@@ -197,7 +197,7 @@ public abstract class Gui {
 	 * If there is no Parent GUI, this method does nothing.
 	 *
 	 * @param viewer the viewer
-	 * @since 2.0.1
+	 * @since 2.1.0
 	 */
 	public void navigateToParent(HumanEntity viewer) {
 		if (parent == null || viewer == null) {
@@ -211,7 +211,7 @@ public abstract class Gui {
 	 * or closes the GUI if there is no parent.
 	 *
 	 * @param viewer the viewer
-	 * @since 2.0.1
+	 * @since 2.1.0
 	 */
 	public void navigateToParentOrClose(HumanEntity viewer) {
 		if (parent == null || viewer == null) {
@@ -227,7 +227,7 @@ public abstract class Gui {
 	 *
 	 * @param gui the GUI to navigate to
 	 * @param viewer the viewer
-	 * @since 2.0.1
+	 * @since 2.1.0
 	 */
 	public void navigateTo(Gui gui, HumanEntity viewer) {
 		if (gui == null || gui == this || viewer == null || !getViewers().contains(viewer)) {


### PR DESCRIPTION
### Description

This pull request adds `parent GUI`s. Every gui can have a `parent GUI` that it navigates to when it's closed by the player. The creation of parent cycles, that is when the `GUI` references itself somewhere in the parent hierarchy prevented by throwing an `IllegalArgumentException`.

### Note

The `title` reflecting the parent-child relationship were considered but not implemented due to significant challenges with the Adventure Component API.